### PR TITLE
Fix post-interaction map flicker for points and coverage bins

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -713,6 +713,7 @@ function App() {
   const previousDeviceIdRef = useRef<string | null>(initial.deviceId);
   const previousCoverageMapLayerRef = useRef<'points' | 'coverage'>('points');
   const previousFocusedCoverageSessionIdRef = useRef<string | null>(null);
+  const coverageBinsBboxCommitTimerRef = useRef<number | null>(null);
 
   const [deviceId, setDeviceId] = useState<string | null>(initial.deviceId);
   const [filterMode, setFilterMode] = useState<'time' | 'session'>(initial.filterMode);
@@ -726,6 +727,9 @@ function App() {
   const [presetAnchorMs, setPresetAnchorMs] = useState(Date.now());
   const [bbox, setBbox] = useState<[number, number, number, number] | null>(null);
   const [pointsBboxCommitted, setPointsBboxCommitted] = useState<
+    [number, number, number, number] | null
+  >(null);
+  const [coverageBinsBboxCommitted, setCoverageBinsBboxCommitted] = useState<
     [number, number, number, number] | null
   >(null);
   const [debouncedBbox, setDebouncedBbox] = useState<[number, number, number, number] | null>(null);
@@ -854,6 +858,63 @@ function App() {
 
     return () => window.clearTimeout(handle);
   }, [bbox]);
+
+  useEffect(() => {
+    if (mapLayerMode !== 'coverage' || coverageVisualizationMode !== 'bins') {
+      if (coverageBinsBboxCommitTimerRef.current !== null) {
+        window.clearTimeout(coverageBinsBboxCommitTimerRef.current);
+        coverageBinsBboxCommitTimerRef.current = null;
+      }
+      return;
+    }
+    if (!bbox) {
+      return;
+    }
+
+    if (coverageBinsBboxCommitTimerRef.current !== null) {
+      window.clearTimeout(coverageBinsBboxCommitTimerRef.current);
+    }
+
+    coverageBinsBboxCommitTimerRef.current = window.setTimeout(() => {
+      coverageBinsBboxCommitTimerRef.current = null;
+      setCoverageBinsBboxCommitted((previous) =>
+        areBboxesEqual(previous, bbox) ? previous : bbox
+      );
+    }, 150);
+
+    return () => {
+      if (coverageBinsBboxCommitTimerRef.current !== null) {
+        window.clearTimeout(coverageBinsBboxCommitTimerRef.current);
+        coverageBinsBboxCommitTimerRef.current = null;
+      }
+    };
+  }, [bbox, mapLayerMode, coverageVisualizationMode]);
+
+  useEffect(() => {
+    if (
+      mapLayerMode !== 'coverage' ||
+      coverageVisualizationMode !== 'bins' ||
+      coverageBinsBboxCommitted ||
+      !bbox
+    ) {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      setCoverageBinsBboxCommitted((previous) =>
+        areBboxesEqual(previous, bbox) ? previous : bbox
+      );
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [mapLayerMode, coverageVisualizationMode, coverageBinsBboxCommitted, bbox]);
+
+  useEffect(() => {
+    return () => {
+      if (coverageBinsBboxCommitTimerRef.current !== null) {
+        window.clearTimeout(coverageBinsBboxCommitTimerRef.current);
+        coverageBinsBboxCommitTimerRef.current = null;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -1166,7 +1227,7 @@ function App() {
   }, []);
 
   const handleBoundsChange = useCallback((nextBbox: [number, number, number, number]) => {
-    setBbox(nextBbox);
+    setBbox((previous) => (areBboxesEqual(previous, nextBbox) ? previous : nextBbox));
     setPointsBboxCommitted((previous) =>
       areBboxesEqual(previous, nextBbox) ? previous : nextBbox
     );
@@ -1814,7 +1875,9 @@ function App() {
     const gatewayId = receiverSource === 'lorawan' ? selectedGatewayId ?? undefined : undefined;
     const coverageLimit = coverageVisualizationMode === 'heatmap' ? 12000 : undefined;
     const coverageBbox =
-      coverageVisualizationMode === 'heatmap' ? undefined : debouncedBbox ?? undefined;
+      coverageVisualizationMode === 'heatmap'
+        ? undefined
+        : coverageBinsBboxCommitted ?? undefined;
     if (coverageScope === 'session') {
       return {
         sessionId: effectiveCoverageSessionId ?? undefined,
@@ -1836,7 +1899,7 @@ function App() {
     coverageScope,
     effectiveCoverageSessionId,
     coverageDay,
-    debouncedBbox,
+    coverageBinsBboxCommitted,
     deviceId,
     selectedGatewayId,
     receiverSource,
@@ -1847,10 +1910,11 @@ function App() {
     {
       enabled:
         mapLayerMode === 'coverage' &&
-        (coverageVisualizationMode === 'heatmap' || Boolean(bboxPayload)) &&
+        (coverageVisualizationMode === 'heatmap' || Boolean(coverageBinsBboxCommitted)) &&
         (coverageScope === 'session'
           ? Boolean(effectiveCoverageSessionId)
-          : Boolean(deviceId))
+          : Boolean(deviceId)),
+      placeholderData: keepPreviousData
     },
     { filterMode: coverageFilterMode }
   );
@@ -2409,6 +2473,7 @@ function App() {
     // the previous viewport (e.g. switching from SF to a Germany session).
     setBbox(null);
     setPointsBboxCommitted(null);
+    setCoverageBinsBboxCommitted(null);
     setDebouncedBbox(null);
   }, [deviceId, selectedSessionId]);
 
@@ -2419,6 +2484,7 @@ function App() {
     setUserInteractedWithMap(false);
     hasAutoFitRef.current = false;
     setBbox(null);
+    setCoverageBinsBboxCommitted(null);
     setDebouncedBbox(null);
   }, [mapLayerMode, coverageScope, effectiveCoverageSessionId]);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -125,6 +125,21 @@ function parseBoolean(value: string | null, defaultValue: boolean): boolean {
   return defaultValue;
 }
 
+function areBboxesEqual(
+  left: [number, number, number, number] | null,
+  right: [number, number, number, number] | null
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return (
+    left[0] === right[0] &&
+    left[1] === right[1] &&
+    left[2] === right[2] &&
+    left[3] === right[3]
+  );
+}
+
 function parsePlaybackSpeed(value: string | null): 0.25 | 0.5 | 1 | 2 | 4 {
   if (!value) {
     return 1;
@@ -710,6 +725,9 @@ function App() {
   const [useAdvancedRange, setUseAdvancedRange] = useState(initial.useAdvancedRange);
   const [presetAnchorMs, setPresetAnchorMs] = useState(Date.now());
   const [bbox, setBbox] = useState<[number, number, number, number] | null>(null);
+  const [pointsBboxCommitted, setPointsBboxCommitted] = useState<
+    [number, number, number, number] | null
+  >(null);
   const [debouncedBbox, setDebouncedBbox] = useState<[number, number, number, number] | null>(null);
   const [currentZoom, setCurrentZoom] = useState(12);
   const [viewMode, setViewMode] = useState<'explore' | 'playback'>(initial.viewMode);
@@ -1147,6 +1165,13 @@ function App() {
     setEventsNavigationNonce((value) => value + 1);
   }, []);
 
+  const handleBoundsChange = useCallback((nextBbox: [number, number, number, number]) => {
+    setBbox(nextBbox);
+    setPointsBboxCommitted((previous) =>
+      areBboxesEqual(previous, nextBbox) ? previous : nextBbox
+    );
+  }, []);
+
   const bboxPayload = useMemo(
     () =>
       debouncedBbox
@@ -1158,6 +1183,18 @@ function App() {
           }
         : undefined,
     [debouncedBbox]
+  );
+  const pointsBboxPayload = useMemo(
+    () =>
+      pointsBboxCommitted
+        ? {
+            minLon: pointsBboxCommitted[0],
+            minLat: pointsBboxCommitted[1],
+            maxLon: pointsBboxCommitted[2],
+            maxLat: pointsBboxCommitted[3]
+          }
+        : undefined,
+    [pointsBboxCommitted]
   );
 
   const isSessionMode = filterMode === 'session';
@@ -1299,13 +1336,15 @@ function App() {
   const sessionBoundOnlyForCoverageDevice = isCoverageExploreMode && coverageScope === 'device';
   const playbackEnabled = isPlaybackMode && hasPlaybackSession;
   const sessionPolling = exploreEnabled && Boolean(scopedExploreSessionId) ? 2000 : false;
+  const exploreMeasurementsBboxPayload =
+    mapLayerMode === 'points' ? pointsBboxPayload : bboxPayload;
   const effectiveExploreMeasurementsParams = useMemo<MeasurementQueryParams>(() => {
     const receiverId = isMeshtasticSource ? selectedReceiverId ?? undefined : undefined;
     const rxGatewayId = !isMeshtasticSource ? selectedGatewayId ?? undefined : undefined;
     if (scopedExploreSessionId) {
       return {
         sessionId: scopedExploreSessionId,
-        bbox: bboxPayload,
+        bbox: exploreMeasurementsBboxPayload,
         receiverId,
         rxGatewayId,
         sessionBoundOnly: sessionBoundOnlyForCoverageDevice,
@@ -1317,7 +1356,7 @@ function App() {
       deviceId: scopedExploreDeviceId ?? undefined,
       from: scopedExploreFrom,
       to: scopedExploreTo,
-      bbox: bboxPayload,
+      bbox: exploreMeasurementsBboxPayload,
       receiverId,
       rxGatewayId,
       sessionBoundOnly: sessionBoundOnlyForCoverageDevice,
@@ -1329,7 +1368,7 @@ function App() {
     scopedExploreDeviceId,
     scopedExploreFrom,
     scopedExploreTo,
-    bboxPayload,
+    exploreMeasurementsBboxPayload,
     selectedGatewayId,
     selectedReceiverId,
     isMeshtasticSource,
@@ -1376,7 +1415,8 @@ function App() {
   const exploreMeasurementsQuery = useMeasurements(
     effectiveExploreMeasurementsParams,
     {
-      enabled: exploreEnabled && exploreScopeEnabled
+      enabled: exploreEnabled && exploreScopeEnabled,
+      placeholderData: keepPreviousData
     },
     { filterMode: exploreQueryFilterMode, refetchIntervalMs: sessionPolling }
   );
@@ -1405,7 +1445,7 @@ function App() {
     if (isSessionMode) {
       return {
         sessionId: selectedSessionId ?? undefined,
-        bbox: bboxPayload,
+        bbox: pointsBboxPayload,
         receiverId,
         rxGatewayId,
         sample: compareSample,
@@ -1416,7 +1456,7 @@ function App() {
       deviceId: deviceId ?? undefined,
       from: exploreRange.from,
       to: exploreRange.to,
-      bbox: bboxPayload,
+      bbox: pointsBboxPayload,
       receiverId,
       rxGatewayId,
       sample: compareSample,
@@ -1425,7 +1465,7 @@ function App() {
   }, [
     isSessionMode,
     selectedSessionId,
-    bboxPayload,
+    pointsBboxPayload,
     compareGatewayId,
     compareReceiverId,
     receiverSource,
@@ -1442,7 +1482,8 @@ function App() {
         exploreEnabled &&
         mapLayerMode === 'points' &&
         Boolean(compareId) &&
-        (isSessionMode ? Boolean(selectedSessionId) : Boolean(deviceId))
+        (isSessionMode ? Boolean(selectedSessionId) : Boolean(deviceId)),
+      placeholderData: keepPreviousData
     },
     { filterMode, refetchIntervalMs: sessionPolling }
   );
@@ -2367,6 +2408,7 @@ function App() {
     // Clear map bounds when the scope changes so the first fetch is not clipped to
     // the previous viewport (e.g. switching from SF to a Germany session).
     setBbox(null);
+    setPointsBboxCommitted(null);
     setDebouncedBbox(null);
   }, [deviceId, selectedSessionId]);
 
@@ -2983,7 +3025,7 @@ function App() {
           deviceLocationMarkers={!isPlaybackMode && showDeviceMarkers ? deviceLocationMarkers : []}
           homeGeofenceOverlay={visibleHomeGeofenceOverlay}
           onSelectDeviceMarker={setDeviceId}
-          onBoundsChange={setBbox}
+          onBoundsChange={handleBoundsChange}
           onSelectPoint={setSelectedPointId}
           onOverviewSelectTime={isPlaybackMode ? handlePlaybackCursorMsChange : undefined}
           onZoomChange={setCurrentZoom}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -218,6 +218,8 @@ function BoundsListener({
   onUserInteraction?: () => void;
 }) {
   const map = useMap();
+  const emitTimerRef = useRef<number | null>(null);
+  const lastZoomCommitAtRef = useRef(0);
 
   const emitBounds = () => {
     if (!onChange) {
@@ -233,6 +235,21 @@ function BoundsListener({
     }
   };
 
+  const cancelPendingEmit = () => {
+    if (emitTimerRef.current !== null) {
+      window.clearTimeout(emitTimerRef.current);
+      emitTimerRef.current = null;
+    }
+  };
+
+  const scheduleBoundsEmit = (delayMs: number) => {
+    cancelPendingEmit();
+    emitTimerRef.current = window.setTimeout(() => {
+      emitTimerRef.current = null;
+      emitBounds();
+    }, delayMs);
+  };
+
   const emitZoom = () => {
     if (!onZoomChange) {
       return;
@@ -245,28 +262,38 @@ function BoundsListener({
 
   useMapEvents({
     load: () => {
-      emitBounds();
       emitZoom();
+      scheduleBoundsEmit(0);
+    },
+    movestart: () => {
+      cancelPendingEmit();
     },
     moveend: () => {
-      emitBounds();
+      // zoomend can trigger an immediate moveend; avoid committing the same bounds twice.
+      if (Date.now() - lastZoomCommitAtRef.current < 80) {
+        return;
+      }
+      scheduleBoundsEmit(150);
     },
     dragstart: () => {
       onUserInteraction?.();
     },
     zoomstart: () => {
       onUserInteraction?.();
+      cancelPendingEmit();
     },
     zoomend: () => {
-      emitBounds();
       emitZoom();
+      lastZoomCommitAtRef.current = Date.now();
+      scheduleBoundsEmit(150);
     }
   });
 
   useEffect(() => {
-    emitBounds();
-    emitZoom();
-  }, [map, onChange, onZoomChange]);
+    return () => {
+      cancelPendingEmit();
+    };
+  }, []);
 
   return null;
 }

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -219,7 +219,7 @@ function BoundsListener({
 }) {
   const map = useMap();
   const emitTimerRef = useRef<number | null>(null);
-  const lastZoomCommitAtRef = useRef(0);
+  const isZoomingRef = useRef(false);
 
   const emitBounds = () => {
     if (!onChange) {
@@ -269,8 +269,7 @@ function BoundsListener({
       cancelPendingEmit();
     },
     moveend: () => {
-      // zoomend can trigger an immediate moveend; avoid committing the same bounds twice.
-      if (Date.now() - lastZoomCommitAtRef.current < 80) {
+      if (isZoomingRef.current) {
         return;
       }
       scheduleBoundsEmit(150);
@@ -280,16 +279,18 @@ function BoundsListener({
     },
     zoomstart: () => {
       onUserInteraction?.();
+      isZoomingRef.current = true;
       cancelPendingEmit();
     },
     zoomend: () => {
       emitZoom();
-      lastZoomCommitAtRef.current = Date.now();
-      scheduleBoundsEmit(150);
+      isZoomingRef.current = false;
     }
   });
 
   useEffect(() => {
+    emitZoom();
+    scheduleBoundsEmit(0);
     return () => {
       cancelPendingEmit();
     };


### PR DESCRIPTION
## What\n- Stabilizes points bbox commits so map interactions trigger one settled refetch instead of multiple commits per zoom/pan\n- Adds committed coverage-bins bbox flow in bins mode so coverage rectangles do not repaint twice after interactions\n- Keeps previous query data visible while fetching to avoid clear/repaint flicker in both points and coverage bins\n\n## Validation\n- npm --prefix frontend run build\n- Manual behavior check target: one request per interaction settle, no delayed second visual jump