### PR TITLE
Release v1.2.0: session comparison workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   </picture>
 </p>
 
-> ✅ **Stable release (v1.1.0)**  
-> LoRaMapr has reached **v1.1.0** and is ready for self-hosted use.  
+> ✅ **Stable release (v1.2.0)**  
+> LoRaMapr has reached **v1.2.0** and is ready for self-hosted use.  
 > Development continues for new features and refinements, with changes tracked through normal release/version notes.
 
 LoRaMapr is a Meshtastic app for mapping real-world coverage.
@@ -24,10 +24,12 @@ By recording the same route multiple times, you can compare antennas, placement,
 - People comparing antenna placement or node setup
 - Users who want real measured coverage, not just node positions on a map
 
-## What's in v1.1.0
+## What's in v1.2.0
 
 - Meshtastic-first ingest path via **Pi Forwarder**, plus supported **LoRaWAN** ingest via TTS webhooks.
 - Session-first workflow for manual capture and **Home Auto Session (HAS)** support for hands-free Meshtastic coverage runs.
+- Dedicated **Session Comparison** workflow for comparing repeated runs side by side with shared map overlays.
+- Decision-oriented compare metrics including **Max range**, **Edge RSSI**, **Edge SNR**, and farthest-point map markers.
 - Coverage workflow with **Bins + Heatmap** visualization and **Device vs Session** scope switching.
 - Production-ready self-hosting baseline with Docker Compose, reverse proxy, health/readiness checks, and startup migration flow.
 - Built-in operational tooling for API keys, database backup/restore, and retention safety defaults.

--- a/docs/release-v1.2.0.md
+++ b/docs/release-v1.2.0.md
@@ -1,0 +1,30 @@
+# Release v1.2.0 - Session Comparison Workflow
+
+## Summary
+- Added a real Session Comparison workflow for repeated coverage tests.
+- Added a stronger comparison entry point in Sessions plus a dedicated compare workspace.
+- Added decision-oriented compare metrics centered on `Max range`, `Edge RSSI`, and `Edge SNR`.
+- Added prominent farthest-point markers on the shared compare map.
+
+## Compare entry and workspace
+- Users can now select `2-4` sessions and start comparison directly from the Sessions workflow.
+- Compare mode now opens as a dedicated workspace with selected count, `Fit all`, and `Exit compare`.
+- The raw sessions list remains available, but is pushed into a secondary `Change compared sessions` section while comparing.
+
+## Comparison outcomes
+- The primary comparison metric is now `Max range` from the configured home/base point.
+- Each compared session shows `Edge RSSI` and `Edge SNR` at that farthest successful point.
+- Session cards also show `Last successful`, `Measurements`, `Total distance`, `Median RSSI`, and `Median SNR`.
+- A compact summary strip highlights the session with the greatest max range, best edge RSSI, and best edge SNR.
+
+## Map judgment
+- Compare mode keeps the shared multi-session track overlay with stable per-session colors.
+- Each session’s farthest successful point is marked clearly on the map for immediate visual judgment.
+- The compare legend is layered and positioned so it stays readable above the rest of the map UI.
+
+## Backend/API
+- Extended the existing `GET /api/sessions/:id/stats` response with `home`, `farthestPoint`, `lastRangePoint`, median signal values, and `signalSourceUsed`.
+- No new analytics endpoint or reporting backend was added.
+
+## Milestone
+- `v1.2.0 — Session Comparison as a real decision workflow` is release-complete for the minimum production-usable comparison feature.

--- a/docs/wiki/Changelog.md
+++ b/docs/wiki/Changelog.md
@@ -8,6 +8,13 @@ For releases with dedicated notes files, those files are linked directly.
 - Use your repository milestones/issues board for planned work.
 - For release-specific details, start with the entries below and linked docs.
 
+## v1.2.0 (2026-04-03)
+
+- Session Comparison release: added a dedicated compare workflow from Sessions for selecting and comparing `2-4` runs together.
+- Decision-oriented compare UX release: compare cards now prioritize max range, edge RSSI/SNR, last successful distance, and median signal summaries.
+- Compare map release: added farthest-point markers, improved compare-mode visual hierarchy, and fixed legend layering/readability.
+- Release notes: `docs/release-v1.2.0.md`.
+
 ## v1.1.0 (2026-03-01)
 
 - Coverage heatmap release: added Heatmap visualization alongside existing Bins rendering for at-a-glance hotspot analysis.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loramapr-frontend",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loramapr-frontend",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loramapr-frontend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Frontend for LoRaMapr, a Meshtastic app for mapping real-world coverage.",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3946,6 +3946,14 @@
     align-items: stretch;
   }
 
+  .sessions-panel__compare-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .session-compare-panel__summary-strip {
+    grid-template-columns: 1fr;
+  }
+
   .session-compare-panel__metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -3975,6 +3983,7 @@
   }
 
   .comparison-legend {
+    top: 4.6rem;
     right: 0.75rem;
     left: 0.75rem;
     max-width: none;
@@ -4924,11 +4933,18 @@
 
 .session-compare-panel {
   display: grid;
-  gap: 0.7rem;
-  padding: 0.8rem;
-  border-radius: 10px;
-  border: 1px solid var(--panel-border);
-  background: var(--panel-bg);
+  gap: 0.8rem;
+}
+
+.session-compare-panel__workspace {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.95rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--panel-accent) 22%, var(--panel-border));
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--panel-accent) 10%, var(--panel-surface)) 0%, var(--panel-bg) 100%);
+  box-shadow: var(--panel-shadow);
 }
 
 .session-compare-panel__header {
@@ -4944,13 +4960,18 @@
   min-width: 0;
 }
 
+.session-compare-panel__eyebrow {
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--panel-accent);
+  font-family: var(--font-mono);
+}
+
 .session-compare-panel__header-copy h4 {
   margin: 0;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--panel-muted);
-  font-family: var(--font-mono);
+  font-size: 1rem;
+  color: var(--panel-text);
 }
 
 .session-compare-panel__header-copy p {
@@ -4997,33 +5018,70 @@
   background: var(--danger-bg);
 }
 
-.session-compare-panel__status {
-  display: inline-flex;
-  align-items: center;
+.session-compare-panel__summary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.55rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.07em;
+}
+
+.session-compare-panel__summary-card {
+  display: grid;
+  gap: 0.22rem;
+  min-width: 0;
+  padding: 0.7rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 70%, transparent);
+  background: color-mix(in srgb, var(--panel-surface) 74%, transparent);
+}
+
+.session-compare-panel__summary-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--panel-muted);
   font-family: var(--font-mono);
 }
 
+.session-compare-panel__summary-card strong {
+  font-size: 0.92rem;
+  color: var(--panel-text);
+}
+
+.session-compare-panel__summary-card span:last-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.76rem;
+  color: var(--panel-muted);
+}
+
+.session-compare-panel__notice {
+  padding: 0.68rem 0.78rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--panel-accent) 28%, var(--border-soft));
+  background: color-mix(in srgb, var(--panel-accent) 8%, var(--panel-bg));
+  color: var(--panel-text);
+  font-size: 0.76rem;
+}
+
 .session-compare-panel__list {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.55rem;
 }
 
 .session-compare-panel__item {
   display: grid;
-  gap: 0.55rem;
-  padding: 0.7rem;
-  border-radius: 9px;
-  border: 1px solid color-mix(in srgb, var(--border-soft) 64%, transparent);
-  background: color-mix(in srgb, var(--panel-surface) 64%, transparent);
+  gap: 0.68rem;
+  padding: 0.8rem;
+  border-radius: 11px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 68%, transparent);
+  background: color-mix(in srgb, var(--panel-surface) 72%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--panel-bg) 82%, transparent);
 }
 
 .session-compare-panel__item.is-muted {
-  opacity: 0.62;
+  opacity: 0.56;
 }
 
 .session-compare-panel__item-top {
@@ -5060,7 +5118,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.86rem;
+  font-size: 0.92rem;
   color: var(--panel-text);
 }
 
@@ -5080,9 +5138,36 @@
   font-family: var(--font-mono);
 }
 
+.session-compare-panel__headline {
+  display: grid;
+  gap: 0.16rem;
+  padding: 0.72rem 0.76rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--comparison-color) 24%, var(--border-soft));
+  background: color-mix(in srgb, var(--comparison-color) 10%, var(--panel-bg));
+}
+
+.session-compare-panel__headline-label {
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.session-compare-panel__headline strong {
+  font-size: 1.15rem;
+  color: var(--panel-text);
+}
+
+.session-compare-panel__headline span:last-child {
+  font-size: 0.74rem;
+  color: var(--panel-muted);
+}
+
 .session-compare-panel__metrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.55rem;
   margin: 0;
 }
@@ -5347,24 +5432,42 @@
 }
 
 .sessions-panel__compare-bar {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.65rem 0.72rem;
-  border-radius: 10px;
-  border: 1px solid color-mix(in srgb, var(--border-soft) 68%, transparent);
-  background: color-mix(in srgb, var(--panel-bg) 76%, transparent);
+  padding: 0.85rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+  background:
+    linear-gradient(155deg, color-mix(in srgb, var(--panel-bg) 88%, transparent) 0%, color-mix(in srgb, var(--panel-surface) 84%, transparent) 100%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--panel-bg) 82%, transparent);
+}
+
+.sessions-panel__compare-bar.is-armed {
+  border-color: color-mix(in srgb, var(--panel-accent) 22%, var(--border-soft));
+}
+
+.sessions-panel__compare-bar.is-ready {
+  border-color: color-mix(in srgb, var(--panel-accent) 52%, var(--border-soft));
+  background:
+    linear-gradient(155deg, color-mix(in srgb, var(--panel-accent) 15%, var(--panel-surface)) 0%, color-mix(in srgb, var(--panel-accent) 6%, var(--panel-bg)) 100%);
+}
+
+.sessions-panel__compare-bar.is-active {
+  border-color: color-mix(in srgb, var(--panel-accent) 64%, var(--border-soft));
+  background:
+    linear-gradient(155deg, color-mix(in srgb, var(--panel-accent) 18%, var(--panel-surface)) 0%, color-mix(in srgb, var(--panel-accent) 8%, var(--panel-bg)) 100%);
 }
 
 .sessions-panel__compare-copy {
   display: grid;
-  gap: 0.15rem;
+  gap: 0.18rem;
   min-width: 0;
 }
 
 .sessions-panel__compare-copy strong {
-  font-size: 0.84rem;
+  font-size: 0.95rem;
   color: var(--panel-text);
 }
 
@@ -5375,9 +5478,9 @@
 
 .sessions-panel__compare-eyebrow {
   font-size: 0.62rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
-  color: var(--panel-muted);
+  color: var(--panel-accent);
   font-family: var(--font-mono);
 }
 
@@ -5393,7 +5496,7 @@
   border: 1px solid var(--border-strong);
   background: var(--panel-surface);
   color: inherit;
-  padding: 0.45rem 0.6rem;
+  padding: 0.52rem 0.72rem;
   border-radius: 8px;
   font-size: 0.74rem;
   letter-spacing: 0.08em;
@@ -5412,8 +5515,57 @@
   cursor: not-allowed;
 }
 
+.sessions-panel__compare-actions button:first-child {
+  border-color: color-mix(in srgb, var(--panel-accent) 46%, var(--border-strong));
+  background: color-mix(in srgb, var(--panel-accent) 12%, var(--panel-surface));
+}
+
 .sessions-panel__compare-clear {
   color: var(--panel-muted);
+}
+
+.sessions-panel__list-shell {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.sessions-panel__list-shell.is-compare-mode {
+  padding-top: 0.1rem;
+}
+
+.sessions-panel__list-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.68rem 0.78rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 70%, transparent);
+  background: color-mix(in srgb, var(--panel-bg) 78%, transparent);
+  color: var(--panel-text);
+  font-size: 0.76rem;
+}
+
+.sessions-panel__list-toggle span {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.sessions-panel__list-toggle strong {
+  font-size: 0.78rem;
+  color: var(--panel-text);
+}
+
+.sessions-panel__list-collapsed {
+  padding: 0.7rem 0.78rem;
+  border-radius: 10px;
+  border: 1px dashed color-mix(in srgb, var(--border-soft) 76%, transparent);
+  color: var(--panel-muted);
+  font-size: 0.76rem;
+  background: color-mix(in srgb, var(--panel-bg) 68%, transparent);
 }
 
 .sessions-panel__active strong {
@@ -5848,11 +6000,12 @@
 
 .comparison-legend {
   position: absolute;
-  top: 1rem;
-  right: 1rem;
-  z-index: 720;
+  top: 4.35rem;
+  left: var(--map-controls-clearance-x);
+  right: auto;
+  z-index: 1110;
   min-width: 13rem;
-  max-width: min(18rem, calc(100vw - 7rem));
+  max-width: min(18rem, calc(100vw - var(--map-controls-clearance-x) - 1rem));
   display: grid;
   gap: 0.45rem;
   padding: 0.7rem 0.78rem;
@@ -5887,7 +6040,7 @@
 
 .comparison-legend__item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.45rem;
   min-width: 0;
 }
@@ -5904,6 +6057,12 @@
   box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 10%, transparent);
 }
 
+.comparison-legend__copy {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+}
+
 .comparison-legend__label {
   min-width: 0;
   overflow: hidden;
@@ -5911,6 +6070,16 @@
   white-space: nowrap;
   font-size: 0.78rem;
   color: var(--panel-text);
+}
+
+.comparison-legend__meta {
+  font-size: 0.66rem;
+  color: var(--panel-muted);
+}
+
+.comparison-highlight--ring,
+.comparison-highlight--core {
+  filter: drop-shadow(0 4px 10px color-mix(in srgb, var(--panel-text) 12%, transparent));
 }
 
 .map-point--hollow {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3940,6 +3940,16 @@
     grid-template-columns: 1fr;
   }
 
+  .session-compare-panel__header,
+  .sessions-panel__compare-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .session-compare-panel__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .layout__sidebar-theme-select {
     min-width: 0;
     width: 100%;
@@ -3962,6 +3972,12 @@
 
   .sessions-panel__header-meta {
     justify-items: start;
+  }
+
+  .comparison-legend {
+    right: 0.75rem;
+    left: 0.75rem;
+    max-width: none;
   }
 
   .events-explorer__virtual-row {
@@ -4030,6 +4046,10 @@
   .controls {
     padding: 0.8rem;
     gap: 0.65rem;
+  }
+
+  .session-compare-panel__metrics {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .device-details__row {
@@ -4902,6 +4922,200 @@
   color: var(--danger-fg);
 }
 
+.session-compare-panel {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel-bg);
+}
+
+.session-compare-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.session-compare-panel__header-copy {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.session-compare-panel__header-copy h4 {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.session-compare-panel__header-copy p {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--panel-muted);
+}
+
+.session-compare-panel__header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.session-compare-panel__button {
+  border: 1px solid var(--border-strong);
+  background: var(--panel-surface);
+  color: var(--panel-text);
+  border-radius: 7px;
+  padding: 0.34rem 0.58rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.session-compare-panel__button:hover:not(:disabled) {
+  background: var(--surface-hover);
+  border-color: var(--border-hover);
+}
+
+.session-compare-panel__button--danger {
+  border-color: var(--danger-border);
+  background: var(--danger-bg-soft);
+  color: var(--danger-fg);
+}
+
+.session-compare-panel__button--danger:hover:not(:disabled) {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+}
+
+.session-compare-panel__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.session-compare-panel__list {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.session-compare-panel__item {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.7rem;
+  border-radius: 9px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 64%, transparent);
+  background: color-mix(in srgb, var(--panel-surface) 64%, transparent);
+}
+
+.session-compare-panel__item.is-muted {
+  opacity: 0.62;
+}
+
+.session-compare-panel__item-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.session-compare-panel__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.session-compare-panel__swatch {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: var(--comparison-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--comparison-color) 24%, transparent);
+  flex: 0 0 auto;
+}
+
+.session-compare-panel__identity-copy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.session-compare-panel__identity-copy strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.86rem;
+  color: var(--panel-text);
+}
+
+.session-compare-panel__identity-copy span {
+  font-size: 0.72rem;
+  color: var(--panel-muted);
+}
+
+.session-compare-panel__visibility {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.session-compare-panel__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.session-compare-panel__metrics div {
+  display: grid;
+  gap: 0.16rem;
+  min-width: 0;
+}
+
+.session-compare-panel__metrics dt {
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.session-compare-panel__metrics dd {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--panel-text);
+}
+
+.session-compare-panel__message {
+  font-size: 0.76rem;
+  color: var(--panel-muted);
+}
+
+.session-compare-panel__message--error {
+  color: var(--danger-fg);
+}
+
 .mini-line-chart {
   position: relative;
   width: 100%;
@@ -5132,6 +5346,76 @@
   gap: 0.5rem;
 }
 
+.sessions-panel__compare-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.65rem 0.72rem;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 68%, transparent);
+  background: color-mix(in srgb, var(--panel-bg) 76%, transparent);
+}
+
+.sessions-panel__compare-copy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.sessions-panel__compare-copy strong {
+  font-size: 0.84rem;
+  color: var(--panel-text);
+}
+
+.sessions-panel__compare-copy span:last-child {
+  font-size: 0.75rem;
+  color: var(--panel-muted);
+}
+
+.sessions-panel__compare-eyebrow {
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.sessions-panel__compare-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.sessions-panel__compare-actions button {
+  border: 1px solid var(--border-strong);
+  background: var(--panel-surface);
+  color: inherit;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.sessions-panel__compare-actions button:not(:disabled):hover {
+  background: var(--surface-hover);
+  border-color: var(--border-hover);
+}
+
+.sessions-panel__compare-actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.sessions-panel__compare-clear {
+  color: var(--panel-muted);
+}
+
 .sessions-panel__active strong {
   color: var(--panel-text);
 }
@@ -5219,6 +5503,32 @@
   align-items: center;
   gap: 0.3rem;
   position: relative;
+}
+
+.sessions-panel__compare-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  padding: 0.14rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--panel-bg);
+  color: var(--panel-muted);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.sessions-panel__compare-toggle input {
+  margin: 0;
+}
+
+.sessions-panel__compare-toggle.is-active {
+  border-color: color-mix(in srgb, var(--panel-accent) 72%, transparent);
+  background: color-mix(in srgb, var(--accent-bg-soft) 88%, transparent);
+  color: var(--panel-text);
 }
 
 .sessions-panel__badge {
@@ -5466,6 +5776,11 @@
   background: var(--accent-bg-soft);
 }
 
+.sessions-panel__item.is-compared:not(.is-selected) {
+  border-color: color-mix(in srgb, var(--panel-accent) 52%, transparent);
+  background: color-mix(in srgb, var(--accent-bg-soft) 52%, transparent);
+}
+
 .sessions-panel__title {
   font-size: 0.9rem;
   font-weight: 600;
@@ -5529,6 +5844,73 @@
 .map-point--latest-halo {
   stroke: var(--map-point-latest-halo);
   fill: var(--map-point-latest-halo);
+}
+
+.comparison-legend {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 720;
+  min-width: 13rem;
+  max-width: min(18rem, calc(100vw - 7rem));
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.7rem 0.78rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+  background: color-mix(in srgb, var(--panel-bg) 88%, transparent);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(10px);
+}
+
+.comparison-legend__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.comparison-legend__header strong {
+  color: var(--panel-text);
+  font-size: 0.66rem;
+}
+
+.comparison-legend__list {
+  display: grid;
+  gap: 0.32rem;
+}
+
+.comparison-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.comparison-legend__item.is-muted {
+  opacity: 0.52;
+}
+
+.comparison-legend__swatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  flex: 0 0 auto;
+  box-shadow: 0 0 0 2px color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.comparison-legend__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.78rem;
+  color: var(--panel-text);
 }
 
 .map-point--hollow {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
-import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useQueries, useQueryClient } from '@tanstack/react-query';
 import { IconChartBar, IconChevronRight, IconFileSearch } from '@tabler/icons-react';
 import {
   getMeasurements,
+  getSessionOverview,
+  getSessionStats,
   getSessionWindow,
   type CoverageQueryParams,
   type MeasurementQueryParams
@@ -11,6 +13,7 @@ import {
 import type {
   CoverageBin,
   Measurement,
+  Session,
   SessionWindowPoint,
   UnifiedEventListItem
 } from './api/types';
@@ -21,6 +24,7 @@ import MapView, { type MapViewHandle } from './components/MapView';
 import PlaybackPanel from './components/PlaybackPanel';
 import PointDetails from './components/PointDetails';
 import SelectedDeviceHeader from './components/SelectedDeviceHeader';
+import type { SessionComparisonItem } from './components/SessionComparisonPanel';
 import StatusStrip from './components/StatusStrip';
 import StatsCard from './components/StatsCard';
 import markDark from './assets/branding/loramapr-mark-dark.png';
@@ -41,6 +45,14 @@ import {
 } from './query/hooks';
 import { useLorawanEvents } from './query/lorawan';
 import { useSessionTimeline, useSessions, useSessionWindow } from './query/sessions';
+import {
+  MAX_COMPARED_SESSIONS,
+  areStringListsEqual,
+  buildSessionDurationMs,
+  formatSessionLabel,
+  getSessionComparisonStyle,
+  parseComparedSessionIds
+} from './sessionComparison';
 import { useAppTour } from './tour/AppTourProvider';
 import type { TourSidebarTabKey } from './tour/steps';
 import { applyEventsNavigationParams, type EventsNavigationInput } from './utils/eventsNavigation';
@@ -52,6 +64,7 @@ const LIMIT_ZOOM_THRESHOLD = 12;
 const BBOX_DEBOUNCE_MS = 300;
 const SAMPLE_ZOOM_LOW = 12;
 const SAMPLE_ZOOM_MEDIUM = 14;
+const COMPARISON_TRACK_SAMPLE = 1200;
 const LORAWAN_DIAG_WINDOW_MINUTES = 10;
 const SIDEBAR_TAB_KEY = 'sidebarTab';
 const ZEN_MODE_KEY = 'zenMode';
@@ -98,6 +111,7 @@ type InitialQueryState = {
   deviceId: string | null;
   filterMode: 'time' | 'session';
   sessionId: string | null;
+  compareSessionIds: string[];
   from: string;
   to: string;
   showPoints: boolean;
@@ -652,6 +666,7 @@ function readInitialQueryState(): InitialQueryState {
       deviceId: null,
       filterMode: 'time',
       sessionId: null,
+      compareSessionIds: [],
       from: '',
       to: '',
       showPoints: true,
@@ -682,6 +697,7 @@ function readInitialQueryState(): InitialQueryState {
     deviceId: params.get('deviceId'),
     filterMode,
     sessionId: params.get('sessionId'),
+    compareSessionIds: parseComparedSessionIds(params.get('compareSessionIds')),
     from: params.get('from') ?? '',
     to: params.get('to') ?? '',
     showPoints: parseBoolean(params.get('showPoints'), true),
@@ -734,6 +750,9 @@ function App() {
   const [deviceId, setDeviceId] = useState<string | null>(initial.deviceId);
   const [filterMode, setFilterMode] = useState<'time' | 'session'>(initial.filterMode);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(initial.sessionId);
+  const [compareSelectionIds, setCompareSelectionIds] = useState<string[]>(initial.compareSessionIds);
+  const [compareSessionIds, setCompareSessionIds] = useState<string[]>(initial.compareSessionIds);
+  const [hiddenComparisonSessionIds, setHiddenComparisonSessionIds] = useState<string[]>([]);
   const [from, setFrom] = useState(initial.from);
   const [to, setTo] = useState(initial.to);
   const [exploreRangePreset, setExploreRangePreset] = useState<ExploreRangePreset>(
@@ -866,6 +885,17 @@ function App() {
   useEffect(() => {
     setPresetAnchorMs(Date.now());
   }, [exploreRangePreset]);
+
+  useEffect(() => {
+    if (compareSessionIds.length < 2) {
+      return;
+    }
+    if (viewMode !== 'explore') {
+      setViewMode('explore');
+    }
+    setPlaybackIsPlaying(false);
+    setSelectedPointId(null);
+  }, [compareSessionIds, viewMode]);
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
@@ -1125,6 +1155,7 @@ function App() {
     setOptional('deviceId', deviceId);
     params.set('filterMode', filterMode);
     setOptional('sessionId', selectedSessionId);
+    setOptional('compareSessionIds', compareSessionIds.length > 0 ? compareSessionIds.join(',') : null);
     params.set('rangePreset', exploreRangePreset);
     if (useAdvancedRange) {
       params.set('rangeAdvanced', 'true');
@@ -1167,6 +1198,7 @@ function App() {
     deviceId,
     filterMode,
     selectedSessionId,
+    compareSessionIds,
     from,
     to,
     showPoints,
@@ -1225,6 +1257,53 @@ function App() {
     setSelectedSessionId(sessionId);
   };
 
+  const handleToggleCompareSelection = useCallback((sessionId: string) => {
+    setCompareSelectionIds((current) => {
+      if (current.includes(sessionId)) {
+        return current.filter((id) => id !== sessionId);
+      }
+      if (current.length >= MAX_COMPARED_SESSIONS) {
+        return current;
+      }
+      return [...current, sessionId];
+    });
+  }, []);
+
+  const handleStartComparison = useCallback(() => {
+    const nextIds = compareSelectionIds.slice(0, MAX_COMPARED_SESSIONS);
+    if (nextIds.length < 2) {
+      return;
+    }
+    setCompareSessionIds(nextIds);
+    setCompareSelectionIds(nextIds);
+    setHiddenComparisonSessionIds([]);
+    setSidebarTab('sessions');
+    setViewMode('explore');
+    setPlaybackIsPlaying(false);
+    setMapLayerMode('points');
+    setSelectedPointId(null);
+  }, [compareSelectionIds]);
+
+  const handleClearCompareSelection = useCallback(() => {
+    setCompareSelectionIds([]);
+    setCompareSessionIds([]);
+    setHiddenComparisonSessionIds([]);
+  }, []);
+
+  const handleExitComparison = useCallback(() => {
+    setCompareSessionIds([]);
+    setHiddenComparisonSessionIds([]);
+    setSelectedPointId(null);
+  }, []);
+
+  const handleToggleComparedSessionVisibility = useCallback((sessionId: string) => {
+    setHiddenComparisonSessionIds((current) =>
+      current.includes(sessionId)
+        ? current.filter((id) => id !== sessionId)
+        : [...current, sessionId]
+    );
+  }, []);
+
   const handleOpenEvents = useCallback((input: EventsNavigationInput) => {
     if (typeof window === 'undefined') {
       return;
@@ -1274,7 +1353,10 @@ function App() {
     [pointsBboxCommitted]
   );
 
+  const compareSessionIdsKey = compareSessionIds.join(',');
   const isSessionMode = filterMode === 'session';
+  const isCompareMode = compareSessionIds.length >= 2;
+  const comparisonSelectionDirty = !areStringListsEqual(compareSelectionIds, compareSessionIds);
   const isPlaybackMode = viewMode === 'playback';
   const focusedCoverageSessionId = isPlaybackMode
     ? playbackSessionId
@@ -1309,6 +1391,26 @@ function App() {
     () => new Set((sessionPickerQuery.data?.items ?? []).map((session) => session.id)),
     [sessionPickerQuery.data?.items]
   );
+  const comparedSessionLookup = useMemo(
+    () =>
+      new Map<string, Session>((sessionPickerQuery.data?.items ?? []).map((session) => [session.id, session])),
+    [sessionPickerQuery.data?.items]
+  );
+  const comparisonStatsQueries = useQueries({
+    queries: compareSessionIds.map((sessionId) => ({
+      queryKey: ['sessionStats', sessionId],
+      queryFn: ({ signal }) => getSessionStats(sessionId, { signal }),
+      enabled: isCompareMode
+    }))
+  });
+  const comparisonOverviewQueries = useQueries({
+    queries: compareSessionIds.map((sessionId) => ({
+      queryKey: ['sessionOverview', sessionId, COMPARISON_TRACK_SAMPLE],
+      queryFn: ({ signal }) =>
+        getSessionOverview(sessionId, { sample: COMPARISON_TRACK_SAMPLE }, { signal }),
+      enabled: isCompareMode
+    }))
+  });
   const playbackMinMs = useMemo(() => {
     if (!playbackTimelineQuery.data?.minCapturedAt) {
       return null;
@@ -1388,7 +1490,7 @@ function App() {
     [playbackSessionId, playbackSampling]
   );
 
-  const exploreEnabled = viewMode !== 'playback';
+  const exploreEnabled = viewMode !== 'playback' && !isCompareMode;
   const isCoverageExploreMode = exploreEnabled && mapLayerMode === 'coverage';
   const scopedExploreSessionId =
     isCoverageExploreMode
@@ -1411,7 +1513,7 @@ function App() {
   const exploreScopeEnabled = Boolean(scopedExploreSessionId || scopedExploreDeviceId);
   const exploreQueryFilterMode: 'time' | 'session' = scopedExploreSessionId ? 'session' : 'time';
   const sessionBoundOnlyForCoverageDevice = isCoverageExploreMode && coverageScope === 'device';
-  const playbackEnabled = isPlaybackMode && hasPlaybackSession;
+  const playbackEnabled = isPlaybackMode && hasPlaybackSession && !isCompareMode;
   const sessionPolling = exploreEnabled && Boolean(scopedExploreSessionId) ? 2000 : false;
   const exploreMeasurementsBboxPayload =
     mapLayerMode === 'points' ? pointsBboxPayload : bboxPayload;
@@ -1682,6 +1784,80 @@ function App() {
       .map((point) => normalizeLatLonItem(point))
       .filter((point): point is NonNullable<typeof point> => point !== null);
   }, [playbackOverviewTrack]);
+  const comparisonItems = useMemo<SessionComparisonItem[]>(
+    () =>
+      compareSessionIds.map((sessionId, index) => {
+        const session = comparedSessionLookup.get(sessionId) ?? null;
+        const stats = comparisonStatsQueries[index]?.data ?? null;
+        const itemError =
+          comparisonStatsQueries[index]?.error ?? comparisonOverviewQueries[index]?.error ?? null;
+
+        return {
+          id: sessionId,
+          label: session ? formatSessionLabel(session) : `Session ${sessionId.slice(0, 8)}`,
+          startedAt: session?.startedAt ?? null,
+          durationMs: buildSessionDurationMs(session, stats),
+          measurementCount: stats?.pointCount ?? null,
+          distanceMeters: stats?.distanceMeters ?? null,
+          avgRssi: stats?.rssi?.avg ?? null,
+          avgSnr: stats?.snr?.avg ?? null,
+          isVisible: !hiddenComparisonSessionIds.includes(sessionId),
+          isLoading:
+            comparisonStatsQueries[index]?.isLoading === true ||
+            comparisonOverviewQueries[index]?.isLoading === true,
+          error: itemError instanceof Error ? itemError.message : null,
+          style: getSessionComparisonStyle(index)
+        };
+      }),
+    [
+      compareSessionIds,
+      comparedSessionLookup,
+      comparisonOverviewQueries,
+      comparisonStatsQueries,
+      hiddenComparisonSessionIds
+    ]
+  );
+  const comparisonTracks = useMemo(
+    () =>
+      compareSessionIds.map((sessionId, index) => {
+        const overviewTrackItems = comparisonOverviewQueries[index]?.data?.items ?? [];
+        return {
+          id: sessionId,
+          label: comparisonItems[index]?.label ?? `Session ${sessionId.slice(0, 8)}`,
+          color: comparisonItems[index]?.style.color ?? getSessionComparisonStyle(index).color,
+          dashArray: comparisonItems[index]?.style.dashArray,
+          isVisible: !hiddenComparisonSessionIds.includes(sessionId),
+          track: overviewTrackItems
+            .map((point) => normalizeLatLonItem(point))
+            .filter((point): point is NonNullable<typeof point> => point !== null)
+        };
+      }),
+    [compareSessionIds, comparisonItems, comparisonOverviewQueries, hiddenComparisonSessionIds]
+  );
+  const comparisonFitPoints = useMemo<LatLonPoint[]>(() => {
+    const trackPoints = comparisonTracks
+      .filter((trackLayer) => trackLayer.isVisible !== false)
+      .flatMap((trackLayer) =>
+        trackLayer.track
+          .map((point) => toLatLonPoint(point.lat, point.lon))
+          .filter((point): point is LatLonPoint => point !== null)
+      );
+    if (trackPoints.length > 0) {
+      return trackPoints;
+    }
+
+    return comparisonItems
+      .filter((item) => item.isVisible)
+      .flatMap((item, index) => {
+        const bbox = comparisonStatsQueries[index]?.data?.bbox;
+        if (!bbox) {
+          return [];
+        }
+        const southWest = toLatLonPoint(bbox.minLat, bbox.minLon);
+        const northEast = toLatLonPoint(bbox.maxLat, bbox.maxLon);
+        return southWest && northEast ? [southWest, northEast] : [];
+      });
+  }, [comparisonItems, comparisonStatsQueries, comparisonTracks]);
   const handleSelectEventForMap = useCallback((event: UnifiedEventListItem) => {
     const candidates = mapMeasurements as Array<{
       id: string;
@@ -1784,11 +1960,20 @@ function App() {
     }
     return toLatLonPoint(playbackCursorPosition[0], playbackCursorPosition[1]);
   }, [playbackCursorPosition]);
+  const comparisonLoading =
+    isCompareMode &&
+    (comparisonStatsQueries.some((query) => query.isLoading) ||
+      comparisonOverviewQueries.some((query) => query.isLoading));
+  const comparisonError = isCompareMode
+    ? comparisonStatsQueries.find((query) => query.error)?.error ??
+      comparisonOverviewQueries.find((query) => query.error)?.error ??
+      null
+    : null;
   const activeMeasurementsQuery = isPlaybackMode
     ? playbackWindowQuery
     : exploreMeasurementsQuery;
   const activeTrackQuery = isPlaybackMode ? null : exploreTrackQuery;
-  const effectiveMapLayerMode = mapLayerMode;
+  const effectiveMapLayerMode = isCompareMode ? 'points' : mapLayerMode;
   const playbackWindowSummary = useMemo(() => {
     if (!isPlaybackMode || !playbackWindowQuery.data) {
       return null;
@@ -1926,6 +2111,7 @@ function App() {
     {
       enabled:
         mapLayerMode === 'coverage' &&
+        !isCompareMode &&
         (coverageVisualizationMode === 'heatmap' || Boolean(coverageBinsBboxCommitted)) &&
         (coverageScope === 'session'
           ? Boolean(effectiveCoverageSessionId)
@@ -1943,7 +2129,9 @@ function App() {
   );
   const renderedPointCount =
     effectiveMapLayerMode === 'points'
-      ? (showPoints ? mapMeasurements.length : 0) + mapCompareMeasurements.length
+      ? isCompareMode
+        ? comparisonTracks.reduce((sum, trackLayer) => sum + trackLayer.track.length, 0)
+        : (showPoints ? mapMeasurements.length : 0) + mapCompareMeasurements.length
       : 0;
   const renderedBinCount = effectiveMapLayerMode === 'coverage' ? coverageBins.length : 0;
 
@@ -2363,11 +2551,18 @@ function App() {
   }, [playbackSessionId]);
 
   useEffect(() => {
+    setHiddenComparisonSessionIds((current) => current.filter((id) => compareSessionIds.includes(id)));
+  }, [compareSessionIds]);
+
+  useEffect(() => {
     if (previousDeviceIdRef.current === deviceId) {
       return;
     }
     previousDeviceIdRef.current = deviceId;
     setSelectedSessionId(null);
+    setCompareSelectionIds([]);
+    setCompareSessionIds([]);
+    setHiddenComparisonSessionIds([]);
     setPlaybackSessionId(null);
     setPlaybackIsPlaying(false);
     if (viewMode === 'playback') {
@@ -2472,7 +2667,7 @@ function App() {
     }
     setPlaybackSessionId(null);
     setPlaybackIsPlaying(false);
-    setSessionSelectionNotice('Playback session was archived or deleted, selection was cleared.');
+      setSessionSelectionNotice('Playback session was archived or deleted, selection was cleared.');
   }, [
     deviceId,
     playbackSessionId,
@@ -2480,6 +2675,40 @@ function App() {
     sessionPickerQuery.isFetching,
     sessionPickerQuery.dataUpdatedAt,
     nonArchivedSessionIds
+  ]);
+
+  useEffect(() => {
+    if (!deviceId || !sessionPickerQuery.isFetched || sessionPickerQuery.isFetching) {
+      return;
+    }
+
+    const nextSelection = compareSelectionIds.filter((id) => nonArchivedSessionIds.has(id));
+    if (!areStringListsEqual(compareSelectionIds, nextSelection)) {
+      setCompareSelectionIds(nextSelection);
+    }
+
+    const nextCompareIds = compareSessionIds.filter((id) => nonArchivedSessionIds.has(id));
+    if (areStringListsEqual(compareSessionIds, nextCompareIds)) {
+      return;
+    }
+
+    setCompareSessionIds(nextCompareIds.length >= 2 ? nextCompareIds : []);
+    setHiddenComparisonSessionIds((current) => current.filter((id) => nextCompareIds.includes(id)));
+
+    if (compareSessionIds.length > 0) {
+      setSessionSelectionNotice(
+        nextCompareIds.length >= 2
+          ? 'Compared session was archived or deleted, comparison was updated.'
+          : 'Compared sessions changed, comparison was cleared.'
+      );
+    }
+  }, [
+    compareSelectionIds,
+    compareSessionIds,
+    deviceId,
+    nonArchivedSessionIds,
+    sessionPickerQuery.isFetched,
+    sessionPickerQuery.isFetching
   ]);
 
   useEffect(() => {
@@ -2491,7 +2720,7 @@ function App() {
     setPointsBboxCommitted(null);
     setCoverageBinsBboxCommitted(null);
     setDebouncedBbox(null);
-  }, [deviceId, selectedSessionId]);
+  }, [deviceId, selectedSessionId, compareSessionIdsKey]);
 
   useEffect(() => {
     if (mapLayerMode !== 'coverage') {
@@ -2517,6 +2746,9 @@ function App() {
   );
 
   useEffect(() => {
+    if (isCompareMode) {
+      return;
+    }
     if (!measurementBounds || !isValidLatLonBounds(measurementBounds)) {
       return;
     }
@@ -2535,9 +2767,47 @@ function App() {
       mapRef.current?.fitBounds(measurementBounds, { padding: [24, 24], maxZoom: 17 });
     }
     hasAutoFitRef.current = true;
-  }, [measurementBounds, userInteractedWithMap, activeMeasurementsQuery.isFetching]);
+  }, [isCompareMode, measurementBounds, userInteractedWithMap, activeMeasurementsQuery.isFetching]);
+
+  useEffect(() => {
+    if (!isCompareMode) {
+      return;
+    }
+    if (comparisonLoading || userInteractedWithMap || hasAutoFitRef.current) {
+      return;
+    }
+    const bounds = buildBoundsFromPoints(comparisonFitPoints);
+    if (!bounds || !isValidLatLonBounds(bounds)) {
+      return;
+    }
+
+    if (comparisonFitPoints.length < 2 || isDegenerateBounds(bounds)) {
+      mapRef.current?.focusPoint(comparisonFitPoints[0], 16);
+    } else {
+      mapRef.current?.fitBounds(bounds, { padding: [24, 24], maxZoom: 17 });
+    }
+    hasAutoFitRef.current = true;
+  }, [comparisonFitPoints, comparisonLoading, isCompareMode, userInteractedWithMap]);
 
   const handleFitToData = () => {
+    if (isCompareMode) {
+      const bounds = buildBoundsFromPoints(comparisonFitPoints);
+      if (comparisonFitPoints.length === 0 || !bounds) {
+        setFitFeedback('No data to fit');
+        return;
+      }
+
+      setFitFeedback(null);
+      if (comparisonFitPoints.length < 2 || isDegenerateBounds(bounds)) {
+        mapRef.current?.focusPoint(comparisonFitPoints[0], 16);
+      } else {
+        mapRef.current?.fitBounds(bounds, { padding: [24, 24], maxZoom: 17 });
+      }
+      setUserInteractedWithMap(true);
+      hasAutoFitRef.current = true;
+      return;
+    }
+
     const playbackPoints: LatLonPoint[] =
       viewMode === 'playback'
         ? playbackWindowPoints
@@ -2768,8 +3038,12 @@ function App() {
     queryClient
   ]);
 
-  const isLoading = activeMeasurementsQuery.isLoading || Boolean(activeTrackQuery?.isLoading);
-  const error = activeMeasurementsQuery.error ?? activeTrackQuery?.error;
+  const isLoading = isCompareMode
+    ? comparisonLoading
+    : activeMeasurementsQuery.isLoading || Boolean(activeTrackQuery?.isLoading);
+  const error = isCompareMode
+    ? comparisonError
+    : activeMeasurementsQuery.error ?? activeTrackQuery?.error;
 
   const latestEvent = lorawanEventsQuery.data?.items?.[0];
   const hasRecentLorawanEvent = (() => {
@@ -3063,6 +3337,16 @@ function App() {
       playbackControls={playbackControls}
       fitFeedback={fitFeedback}
       sessionSelectionNotice={sessionSelectionNotice}
+      comparisonActive={isCompareMode}
+      comparisonSelectionIds={compareSelectionIds}
+      comparisonSelectionDirty={comparisonSelectionDirty}
+      comparisonItems={comparisonItems}
+      onToggleCompareSelection={handleToggleCompareSelection}
+      onStartComparison={handleStartComparison}
+      onClearCompareSelection={handleClearCompareSelection}
+      onExitComparison={handleExitComparison}
+      onToggleComparedSessionVisibility={handleToggleComparedSessionVisibility}
+      onFitComparedSessions={handleFitToData}
       eventsNavigationNonce={eventsNavigationNonce}
       eventsNavigationRequest={eventsNavigationRequest}
       onOpenEvents={handleOpenEvents}
@@ -3095,9 +3379,10 @@ function App() {
           coverageScope={coverageScope}
           coverageVisualizationMode={coverageVisualizationMode}
           coverageMetric={coverageMetric}
-          measurements={mapMeasurements}
-          compareMeasurements={mapCompareMeasurements}
-          track={mapTrackPoints}
+          measurements={isCompareMode ? [] : mapMeasurements}
+          compareMeasurements={isCompareMode ? [] : mapCompareMeasurements}
+          comparisonTracks={isCompareMode ? comparisonTracks : []}
+          track={isCompareMode ? [] : mapTrackPoints}
           overviewTrack={isPlaybackMode ? mapOverviewTrack : []}
           coverageBins={coverageBins}
           coverageBinSize={coverageQuery.data?.binSizeDeg ?? null}
@@ -3118,6 +3403,31 @@ function App() {
           selectedPointId={selectedPointId}
           onUserInteraction={() => setUserInteractedWithMap(true)}
         />
+        {isCompareMode && comparisonItems.length > 0 ? (
+          <div className="comparison-legend" role="region" aria-label="Compared sessions legend">
+            <div className="comparison-legend__header">
+              <span>Session comparison</span>
+              <strong>{comparisonItems.filter((item) => item.isVisible).length} visible</strong>
+            </div>
+            <div className="comparison-legend__list">
+              {comparisonItems.map((item) => (
+                <div
+                  key={item.id}
+                  className={`comparison-legend__item${item.isVisible ? '' : ' is-muted'}`}
+                >
+                  <span
+                    className="comparison-legend__swatch"
+                    style={{ backgroundColor: item.style.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="comparison-legend__label" title={item.label}>
+                    {item.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
         {!zenMode && viewMode === 'playback' && !playbackSessionId && (
           <div className="playback-blocker" role="alert">
             <div className="playback-blocker__message">Select a session</div>
@@ -3131,11 +3441,12 @@ function App() {
           </div>
         )}
         {!zenMode &&
+          !isCompareMode &&
           activeMeasurementsQuery.data &&
           activeMeasurementsQuery.data.items.length === activeMeasurementsQuery.data.limit && (
             <div className="limit-banner">Result limited; zoom in or narrow filters</div>
           )}
-        {!zenMode && shouldShowLorawanBanner && (
+        {!zenMode && !isCompareMode && shouldShowLorawanBanner && (
           <div className="diagnostic-banner">
             LoRaWAN uplinks received, but decoded payload has no lat/lon. Configure payload formatter
             to output GPS.{' '}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import {
   MAX_COMPARED_SESSIONS,
   areStringListsEqual,
   buildSessionDurationMs,
+  formatDistanceMeters,
   formatSessionLabel,
   getSessionComparisonStyle,
   parseComparedSessionIds
@@ -1795,12 +1796,14 @@ function App() {
         return {
           id: sessionId,
           label: session ? formatSessionLabel(session) : `Session ${sessionId.slice(0, 8)}`,
-          startedAt: session?.startedAt ?? null,
+          startedAt: session?.startedAt ?? stats?.startedAt ?? null,
           durationMs: buildSessionDurationMs(session, stats),
           measurementCount: stats?.pointCount ?? null,
           distanceMeters: stats?.distanceMeters ?? null,
-          avgRssi: stats?.rssi?.avg ?? null,
-          avgSnr: stats?.snr?.avg ?? null,
+          medianRssi: stats?.rssi?.median ?? null,
+          medianSnr: stats?.snr?.median ?? null,
+          farthestPoint: stats?.farthestPoint ?? null,
+          lastRangePoint: stats?.lastRangePoint ?? null,
           isVisible: !hiddenComparisonSessionIds.includes(sessionId),
           isLoading:
             comparisonStatsQueries[index]?.isLoading === true ||
@@ -1834,7 +1837,36 @@ function App() {
       }),
     [compareSessionIds, comparisonItems, comparisonOverviewQueries, hiddenComparisonSessionIds]
   );
+  const comparisonHighlights = useMemo(
+    () =>
+      compareSessionIds
+        .map((sessionId, index) => {
+          const farthestPoint = comparisonStatsQueries[index]?.data?.farthestPoint ?? null;
+          if (!farthestPoint) {
+            return null;
+          }
+
+          return {
+            id: sessionId,
+            label: comparisonItems[index]?.label ?? `Session ${sessionId.slice(0, 8)}`,
+            color: comparisonItems[index]?.style.color ?? getSessionComparisonStyle(index).color,
+            dashArray: comparisonItems[index]?.style.dashArray,
+            isVisible: !hiddenComparisonSessionIds.includes(sessionId),
+            lat: farthestPoint.lat,
+            lon: farthestPoint.lon,
+            distanceMeters: farthestPoint.distanceMeters,
+            rssi: farthestPoint.rssi,
+            snr: farthestPoint.snr
+          };
+        })
+        .filter((highlight): highlight is NonNullable<typeof highlight> => highlight !== null),
+    [compareSessionIds, comparisonItems, comparisonStatsQueries, hiddenComparisonSessionIds]
+  );
   const comparisonFitPoints = useMemo<LatLonPoint[]>(() => {
+    const highlightPoints = comparisonHighlights
+      .filter((highlight) => highlight.isVisible !== false)
+      .map((highlight) => toLatLonPoint(highlight.lat, highlight.lon))
+      .filter((point): point is LatLonPoint => point !== null);
     const trackPoints = comparisonTracks
       .filter((trackLayer) => trackLayer.isVisible !== false)
       .flatMap((trackLayer) =>
@@ -1843,7 +1875,11 @@ function App() {
           .filter((point): point is LatLonPoint => point !== null)
       );
     if (trackPoints.length > 0) {
-      return trackPoints;
+      return [...trackPoints, ...highlightPoints];
+    }
+
+    if (highlightPoints.length > 0) {
+      return highlightPoints;
     }
 
     return comparisonItems
@@ -1857,7 +1893,7 @@ function App() {
         const northEast = toLatLonPoint(bbox.maxLat, bbox.maxLon);
         return southWest && northEast ? [southWest, northEast] : [];
       });
-  }, [comparisonItems, comparisonStatsQueries, comparisonTracks]);
+  }, [comparisonHighlights, comparisonItems, comparisonStatsQueries, comparisonTracks]);
   const handleSelectEventForMap = useCallback((event: UnifiedEventListItem) => {
     const candidates = mapMeasurements as Array<{
       id: string;
@@ -3382,6 +3418,7 @@ function App() {
           measurements={isCompareMode ? [] : mapMeasurements}
           compareMeasurements={isCompareMode ? [] : mapCompareMeasurements}
           comparisonTracks={isCompareMode ? comparisonTracks : []}
+          comparisonHighlights={isCompareMode ? comparisonHighlights : []}
           track={isCompareMode ? [] : mapTrackPoints}
           overviewTrack={isPlaybackMode ? mapOverviewTrack : []}
           coverageBins={coverageBins}
@@ -3420,9 +3457,14 @@ function App() {
                     style={{ backgroundColor: item.style.color }}
                     aria-hidden="true"
                   />
-                  <span className="comparison-legend__label" title={item.label}>
-                    {item.label}
-                  </span>
+                  <div className="comparison-legend__copy">
+                    <span className="comparison-legend__label" title={item.label}>
+                      {item.label}
+                    </span>
+                    <span className="comparison-legend__meta">
+                      Max range {formatDistanceMeters(item.farthestPoint?.distanceMeters ?? null)}
+                    </span>
+                  </div>
                 </div>
               ))}
             </div>

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -25,6 +25,7 @@ import type {
   SessionSignalSeries,
   SessionSignalHistogram,
   Session,
+  SessionOverviewResponse,
   TrackPoint,
   SystemStatus,
   UnifiedEventDetail,
@@ -601,6 +602,22 @@ export async function getSessionWindow(
   const query = searchParams.toString();
   const path = `/api/sessions/${params.sessionId}/window${query ? `?${query}` : ''}`;
   return getJson<SessionWindowResponse>(path, options);
+}
+
+export async function getSessionOverview(
+  sessionId: string,
+  params?: { sample?: number },
+  options?: RequestOptions
+): Promise<SessionOverviewResponse> {
+  const searchParams = new URLSearchParams();
+  if (typeof params?.sample === 'number') {
+    searchParams.set('sample', String(params.sample));
+  }
+  const suffix = searchParams.toString();
+  const path = suffix
+    ? `/api/sessions/${sessionId}/overview?${suffix}`
+    : `/api/sessions/${sessionId}/overview`;
+  return getJson<SessionOverviewResponse>(path, options);
 }
 
 export async function getMeasurements(

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -229,6 +229,11 @@ export type SessionWindowResponse = {
   items: SessionWindowPoint[];
 };
 
+export type SessionOverviewResponse = {
+  sessionId: string;
+  items: TrackPoint[];
+};
+
 export type TrackPoint = {
   capturedAt: string;
   lat: number;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -158,16 +158,40 @@ export type SessionStats = {
     maxLat: number;
     maxLon: number;
   } | null;
+  home: {
+    lat: number;
+    lon: number;
+    radiusMeters: number;
+  } | null;
+  farthestPoint: {
+    capturedAt: string;
+    lat: number;
+    lon: number;
+    distanceMeters: number;
+    rssi: number | null;
+    snr: number | null;
+  } | null;
+  lastRangePoint: {
+    capturedAt: string;
+    lat: number;
+    lon: number;
+    distanceMeters: number;
+    rssi: number | null;
+    snr: number | null;
+  } | null;
   rssi: {
     min: number | null;
     max: number | null;
     avg: number | null;
+    median: number | null;
   } | null;
   snr: {
     min: number | null;
     max: number | null;
     avg: number | null;
+    median: number | null;
   } | null;
+  signalSourceUsed: 'meshtastic' | 'lorawan' | 'measurement' | null;
   receiversCount: number | null;
 };
 

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -36,6 +36,7 @@ import GatewayStatsPanel from './GatewayStatsPanel';
 import LorawanEventsPanel from './LorawanEventsPanel';
 import MeshtasticEventsPanel from './MeshtasticEventsPanel';
 import ReceiverStatsPanel from './ReceiverStatsPanel';
+import SessionComparisonPanel, { type SessionComparisonItem } from './SessionComparisonPanel';
 import SessionsPanel from './SessionsPanel';
 import SessionDetailsPanel from './SessionDetailsPanel';
 import EventsExplorerPanel from './EventsExplorerPanel';
@@ -123,6 +124,16 @@ type ControlsProps = {
   playbackControls?: ReactNode;
   fitFeedback?: string | null;
   sessionSelectionNotice?: string | null;
+  comparisonActive: boolean;
+  comparisonSelectionIds: string[];
+  comparisonSelectionDirty: boolean;
+  comparisonItems: SessionComparisonItem[];
+  onToggleCompareSelection: (sessionId: string) => void;
+  onStartComparison: () => void;
+  onClearCompareSelection: () => void;
+  onExitComparison: () => void;
+  onToggleComparedSessionVisibility: (sessionId: string) => void;
+  onFitComparedSessions: () => void;
   eventsNavigationNonce: number;
   eventsNavigationRequest: EventsNavigationInput | null;
   onOpenEvents: (input: EventsNavigationInput) => void;
@@ -190,6 +201,16 @@ export default function Controls({
   playbackControls,
   fitFeedback,
   sessionSelectionNotice,
+  comparisonActive,
+  comparisonSelectionIds,
+  comparisonSelectionDirty,
+  comparisonItems,
+  onToggleCompareSelection,
+  onStartComparison,
+  onClearCompareSelection,
+  onExitComparison,
+  onToggleComparedSessionVisibility,
+  onFitComparedSessions,
   eventsNavigationNonce,
   eventsNavigationRequest,
   onOpenEvents,
@@ -1687,12 +1708,19 @@ export default function Controls({
         <div className="controls__group">
           {deviceId ? (
             <>
-              {filterMode === 'session' && !selectedSessionId ? (
+              {!comparisonActive && filterMode === 'session' && !selectedSessionId ? (
                 <div className="controls__session-empty-state" role="status" aria-live="polite">
                   Select a session
                 </div>
               ) : null}
-              {selectedSessionId ? (
+              {comparisonActive ? (
+                <SessionComparisonPanel
+                  items={comparisonItems}
+                  onToggleVisibility={onToggleComparedSessionVisibility}
+                  onClearComparison={onExitComparison}
+                  onFitAll={onFitComparedSessions}
+                />
+              ) : selectedSessionId ? (
                 <SessionDetailsPanel
                   sessionId={selectedSessionId}
                   onFitMapToSession={onFitMapToSession}
@@ -1701,8 +1729,14 @@ export default function Controls({
               <SessionsPanel
                 deviceId={deviceId}
                 selectedSessionId={selectedSessionId}
+                compareSelectionIds={comparisonSelectionIds}
+                comparisonActive={comparisonActive}
+                comparisonSelectionDirty={comparisonSelectionDirty}
                 onSelectSessionId={onSelectSessionId}
                 onStartSession={onStartSession}
+                onToggleCompareSelection={onToggleCompareSelection}
+                onStartComparison={onStartComparison}
+                onClearCompareSelection={onClearCompareSelection}
               />
             </>
           ) : (

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -90,6 +90,7 @@ type MapViewProps = {
   coverageMetric?: 'count' | 'rssiAvg' | 'snrAvg';
   measurements?: MapPoint[];
   compareMeasurements?: MapPoint[];
+  comparisonTracks?: ComparisonTrack[];
   track?: TrackPoint[];
   overviewTrack?: TrackPoint[];
   coverageBins?: CoverageBin[];
@@ -125,6 +126,15 @@ type TrackPoint = {
   lat: number;
   lon: number;
   capturedAt: string;
+};
+
+type ComparisonTrack = {
+  id: string;
+  label: string;
+  color: string;
+  dashArray?: string;
+  isVisible?: boolean;
+  track: TrackPoint[];
 };
 
 type LatestLocationMarker = {
@@ -775,6 +785,39 @@ function buildTrackPositionsFromMeasurements(points: readonly MapPoint[]): [numb
   return valid.map((point) => [point.lat, point.lon] as [number, number]);
 }
 
+function buildSimplifiedTrackPositions(
+  points: readonly Pick<TrackPoint, 'lat' | 'lon'>[],
+  zoom: number
+): [number, number][] {
+  const validTrack = filterValidTrackCoordinates(points);
+  if (validTrack.length === 0) {
+    return [];
+  }
+  if (validTrack.length <= 2) {
+    return validTrack.map((point) => [point.lat, point.lon] as [number, number]);
+  }
+
+  const tolerance = zoomToTolerance(zoom);
+  const simplified = simplify(
+    validTrack.map((point) => ({ x: point.lon, y: point.lat })),
+    tolerance,
+    true
+  );
+  const positions = simplified.map((point) => [point.y, point.x] as [number, number]);
+  const first = [validTrack[0].lat, validTrack[0].lon] as [number, number];
+  const last = [validTrack[validTrack.length - 1].lat, validTrack[validTrack.length - 1].lon] as [
+    number,
+    number
+  ];
+
+  if (positions.length > 0) {
+    positions[0] = first;
+    positions[positions.length - 1] = last;
+  }
+
+  return positions;
+}
+
 function readPalette(): PointPalette {
   if (typeof window === 'undefined') {
     return {
@@ -838,6 +881,7 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
   coverageMetric = 'count',
   measurements = [],
   compareMeasurements = [],
+  comparisonTracks = [],
   track = [],
   overviewTrack = [],
   coverageBins = [],
@@ -947,30 +991,7 @@ ref
     if (!shouldRenderTracks || track.length === 0) {
       return [];
     }
-    const validTrack = filterValidTrackCoordinates(track);
-    if (validTrack.length === 0) {
-      return [];
-    }
-    if (validTrack.length <= 2) {
-      return validTrack.map((point) => [point.lat, point.lon] as [number, number]);
-    }
-
-    const tolerance = zoomToTolerance(currentZoom);
-    const points = validTrack.map((point) => ({ x: point.lon, y: point.lat }));
-    const simplified = simplify(points, tolerance, true);
-    const positions = simplified.map((point) => [point.y, point.x] as [number, number]);
-
-    const first = [validTrack[0].lat, validTrack[0].lon] as [number, number];
-    const last = [
-      validTrack[validTrack.length - 1].lat,
-      validTrack[validTrack.length - 1].lon
-    ] as [number, number];
-    if (positions.length > 0) {
-      positions[0] = first;
-      positions[positions.length - 1] = last;
-    }
-
-    return positions;
+    return buildSimplifiedTrackPositions(track, currentZoom);
   }, [currentZoom, mapLayerMode, measurements, shouldRenderTracks, showPoints, track]);
 
   const overviewTrackPoints = useMemo(
@@ -989,31 +1010,19 @@ ref
     if (!shouldRenderTracks || overviewTrack.length === 0) {
       return [];
     }
-    const validOverview = filterValidTrackCoordinates(overviewTrack);
-    if (validOverview.length === 0) {
-      return [];
-    }
-    if (validOverview.length <= 2) {
-      return validOverview.map((point) => [point.lat, point.lon] as [number, number]);
-    }
-
-    const tolerance = zoomToTolerance(currentZoom);
-    const points = validOverview.map((point) => ({ x: point.lon, y: point.lat }));
-    const simplified = simplify(points, tolerance, true);
-    const positions = simplified.map((point) => [point.y, point.x] as [number, number]);
-
-    const first = [validOverview[0].lat, validOverview[0].lon] as [number, number];
-    const last = [
-      validOverview[validOverview.length - 1].lat,
-      validOverview[validOverview.length - 1].lon
-    ] as [number, number];
-    if (positions.length > 0) {
-      positions[0] = first;
-      positions[positions.length - 1] = last;
-    }
-
-    return positions;
+    return buildSimplifiedTrackPositions(overviewTrack, currentZoom);
   }, [overviewTrack, currentZoom, shouldRenderTracks]);
+  const comparisonTrackEntries = useMemo(
+    () =>
+      comparisonTracks
+        .filter((trackLayer) => trackLayer.isVisible !== false)
+        .map((trackLayer) => ({
+          ...trackLayer,
+          positions: buildSimplifiedTrackPositions(trackLayer.track, currentZoom)
+        }))
+        .filter((trackLayer) => trackLayer.positions.length > 0),
+    [comparisonTracks, currentZoom]
+  );
 
   const furthestPointIdFromHome = useMemo(() => {
     if (
@@ -1381,6 +1390,22 @@ ref
           />
         </>
       )}
+      {comparisonTrackEntries.map((trackLayer) => (
+        <Polyline
+          key={`comparison-track-${trackLayer.id}`}
+          positions={trackLayer.positions}
+          pathOptions={{
+            pane: MAP_LAYER_PANES.sessionTrack,
+            color: trackLayer.color,
+            opacity: 0.88,
+            weight: 3,
+            dashArray: trackLayer.dashArray,
+            lineCap: 'round',
+            lineJoin: 'round'
+          }}
+          interactive={false}
+        />
+      ))}
       {mapLayerMode === 'coverage' &&
         coverageVisualizationMode === 'bins' &&
         coverageData.bins.map((bin) => {

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -59,12 +59,14 @@ import {
   resolveArrowSpacingPx,
   sampleArrowPlacementsAtDistance
 } from '../map/trackDirection';
+import { formatDistanceMeters, formatSignalMetric } from '../sessionComparison';
 
 const DEFAULT_CENTER: [number, number] = [37.7749, -122.4194];
 const DEFAULT_ZOOM = 12;
 const MAP_LAYER_PANES = {
   sessionPointsRegular: 'session-points-regular',
   sessionTrack: 'session-track',
+  comparisonHighlights: 'comparison-highlights',
   sessionPointsActive: 'session-points-active',
   sessionPointHits: 'session-point-hits'
 } as const;
@@ -91,6 +93,7 @@ type MapViewProps = {
   measurements?: MapPoint[];
   compareMeasurements?: MapPoint[];
   comparisonTracks?: ComparisonTrack[];
+  comparisonHighlights?: ComparisonHighlight[];
   track?: TrackPoint[];
   overviewTrack?: TrackPoint[];
   coverageBins?: CoverageBin[];
@@ -135,6 +138,19 @@ type ComparisonTrack = {
   dashArray?: string;
   isVisible?: boolean;
   track: TrackPoint[];
+};
+
+type ComparisonHighlight = {
+  id: string;
+  label: string;
+  color: string;
+  dashArray?: string;
+  isVisible?: boolean;
+  lat: number;
+  lon: number;
+  distanceMeters: number;
+  rssi: number | null;
+  snr: number | null;
 };
 
 type LatestLocationMarker = {
@@ -882,6 +898,7 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(function MapView(
   measurements = [],
   compareMeasurements = [],
   comparisonTracks = [],
+  comparisonHighlights = [],
   track = [],
   overviewTrack = [],
   coverageBins = [],
@@ -1326,6 +1343,7 @@ ref
       )}
       <Pane name={MAP_LAYER_PANES.sessionPointsRegular} style={{ zIndex: 390 }} />
       <Pane name={MAP_LAYER_PANES.sessionTrack} style={{ zIndex: 410 }} />
+      <Pane name={MAP_LAYER_PANES.comparisonHighlights} style={{ zIndex: 420 }} />
       <Pane name={MAP_LAYER_PANES.sessionPointsActive} style={{ zIndex: 430 }} />
       <Pane name={MAP_LAYER_PANES.sessionPointHits} style={{ zIndex: 440 }} />
       {mapLayerMode === 'coverage' && coverageVisualizationMode === 'heatmap' && (
@@ -1406,6 +1424,50 @@ ref
           interactive={false}
         />
       ))}
+      {comparisonHighlights
+        .filter((highlight) => highlight.isVisible !== false)
+        .map((highlight) =>
+          Number.isFinite(highlight.lat) && Number.isFinite(highlight.lon) ? (
+            <Fragment key={`comparison-highlight-${highlight.id}`}>
+              <CircleMarker
+                center={[highlight.lat, highlight.lon]}
+                radius={13}
+                pathOptions={{
+                  pane: MAP_LAYER_PANES.comparisonHighlights,
+                  color: highlight.color,
+                  weight: 3.5,
+                  opacity: 0.96,
+                  fillColor: highlight.color,
+                  fillOpacity: 0.12,
+                  className: 'comparison-highlight comparison-highlight--ring'
+                }}
+                interactive={false}
+              />
+              <CircleMarker
+                center={[highlight.lat, highlight.lon]}
+                radius={6.5}
+                pathOptions={{
+                  pane: MAP_LAYER_PANES.comparisonHighlights,
+                  color: '#ffffff',
+                  weight: 1.5,
+                  opacity: 0.94,
+                  fillColor: highlight.color,
+                  fillOpacity: 0.96,
+                  className: 'comparison-highlight comparison-highlight--core'
+                }}
+              >
+                <Tooltip direction="top" offset={[0, -10]} opacity={0.96}>
+                  <div>
+                    <strong>{highlight.label}</strong>
+                    <div>Max range: {formatDistanceMeters(highlight.distanceMeters)}</div>
+                    <div>Edge RSSI: {formatSignalMetric(highlight.rssi, 'rssi')}</div>
+                    <div>Edge SNR: {formatSignalMetric(highlight.snr, 'snr')}</div>
+                  </div>
+                </Tooltip>
+              </CircleMarker>
+            </Fragment>
+          ) : null
+        )}
       {mapLayerMode === 'coverage' &&
         coverageVisualizationMode === 'bins' &&
         coverageData.bins.map((bin) => {

--- a/frontend/src/components/SessionComparisonPanel.tsx
+++ b/frontend/src/components/SessionComparisonPanel.tsx
@@ -1,0 +1,138 @@
+import type { CSSProperties } from 'react';
+import {
+  formatDistanceMeters,
+  formatSessionDuration,
+  formatSessionTimestamp,
+  formatSignalMetric,
+  type SessionComparisonStyle
+} from '../sessionComparison';
+
+export type SessionComparisonItem = {
+  id: string;
+  label: string;
+  startedAt: string | null | undefined;
+  durationMs: number | null;
+  measurementCount: number | null;
+  distanceMeters: number | null;
+  avgRssi: number | null;
+  avgSnr: number | null;
+  isVisible: boolean;
+  isLoading: boolean;
+  error: string | null;
+  style: SessionComparisonStyle;
+};
+
+type SessionComparisonPanelProps = {
+  items: SessionComparisonItem[];
+  onToggleVisibility: (sessionId: string) => void;
+  onClearComparison: () => void;
+  onFitAll: () => void;
+};
+
+export default function SessionComparisonPanel({
+  items,
+  onToggleVisibility,
+  onClearComparison,
+  onFitAll
+}: SessionComparisonPanelProps) {
+  if (items.length < 2) {
+    return null;
+  }
+
+  const visibleCount = items.filter((item) => item.isVisible).length;
+
+  return (
+    <section className="session-compare-panel" aria-label="Session comparison">
+      <div className="session-compare-panel__header">
+        <div className="session-compare-panel__header-copy">
+          <h4>Session comparison</h4>
+          <p>
+            Reviewing {items.length} sessions together. Colors match the shared map overlay.
+          </p>
+        </div>
+        <div className="session-compare-panel__header-actions">
+          <button type="button" className="session-compare-panel__button" onClick={onFitAll}>
+            Fit all
+          </button>
+          <button
+            type="button"
+            className="session-compare-panel__button session-compare-panel__button--danger"
+            onClick={onClearComparison}
+          >
+            Exit compare
+          </button>
+        </div>
+      </div>
+      <div className="session-compare-panel__status">
+        <span>{visibleCount} visible</span>
+        <span>{items.length - visibleCount} hidden</span>
+      </div>
+      <div className="session-compare-panel__list">
+        {items.map((item) => {
+          const swatchStyle = {
+            '--comparison-color': item.style.color
+          } as CSSProperties;
+
+          return (
+            <article
+              key={item.id}
+              className={`session-compare-panel__item${item.isVisible ? '' : ' is-muted'}`}
+            >
+              <div className="session-compare-panel__item-top">
+                <div className="session-compare-panel__identity">
+                  <span className="session-compare-panel__swatch" style={swatchStyle} aria-hidden="true" />
+                  <div className="session-compare-panel__identity-copy">
+                    <strong title={item.label}>{item.label}</strong>
+                    <span>{formatSessionTimestamp(item.startedAt)}</span>
+                  </div>
+                </div>
+                <label className="session-compare-panel__visibility">
+                  <input
+                    type="checkbox"
+                    checked={item.isVisible}
+                    onChange={() => onToggleVisibility(item.id)}
+                  />
+                  Visible
+                </label>
+              </div>
+              {item.error ? (
+                <div className="session-compare-panel__message session-compare-panel__message--error">
+                  {item.error}
+                </div>
+              ) : item.isLoading ? (
+                <div className="session-compare-panel__message">Loading comparison data…</div>
+              ) : (
+                <dl className="session-compare-panel__metrics">
+                  <div>
+                    <dt>Duration</dt>
+                    <dd>{formatSessionDuration(item.durationMs)}</dd>
+                  </div>
+                  <div>
+                    <dt>Points</dt>
+                    <dd>
+                      {item.measurementCount !== null && item.measurementCount !== undefined
+                        ? item.measurementCount.toLocaleString()
+                        : '—'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Distance</dt>
+                    <dd>{formatDistanceMeters(item.distanceMeters)}</dd>
+                  </div>
+                  <div>
+                    <dt>Avg RSSI</dt>
+                    <dd>{formatSignalMetric(item.avgRssi, 'rssi')}</dd>
+                  </div>
+                  <div>
+                    <dt>Avg SNR</dt>
+                    <dd>{formatSignalMetric(item.avgSnr, 'snr')}</dd>
+                  </div>
+                </dl>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/SessionComparisonPanel.tsx
+++ b/frontend/src/components/SessionComparisonPanel.tsx
@@ -7,6 +7,15 @@ import {
   type SessionComparisonStyle
 } from '../sessionComparison';
 
+export type SessionComparisonRangePoint = {
+  capturedAt: string;
+  lat: number;
+  lon: number;
+  distanceMeters: number;
+  rssi: number | null;
+  snr: number | null;
+};
+
 export type SessionComparisonItem = {
   id: string;
   label: string;
@@ -14,8 +23,10 @@ export type SessionComparisonItem = {
   durationMs: number | null;
   measurementCount: number | null;
   distanceMeters: number | null;
-  avgRssi: number | null;
-  avgSnr: number | null;
+  medianRssi: number | null;
+  medianSnr: number | null;
+  farthestPoint: SessionComparisonRangePoint | null;
+  lastRangePoint: SessionComparisonRangePoint | null;
   isVisible: boolean;
   isLoading: boolean;
   error: string | null;
@@ -29,6 +40,99 @@ type SessionComparisonPanelProps = {
   onFitAll: () => void;
 };
 
+type ComparisonLeaderMetric = 'range' | 'rssi' | 'snr';
+
+type ComparisonLeader = {
+  label: string;
+  sessionLabel: string;
+  value: string;
+  color: string;
+};
+
+function formatMeasurementCount(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '—';
+  }
+  return value.toLocaleString();
+}
+
+function pickComparisonLeader(
+  items: SessionComparisonItem[],
+  metric: ComparisonLeaderMetric
+): ComparisonLeader | null {
+  let leader: SessionComparisonItem | null = null;
+  let leaderValue = Number.NEGATIVE_INFINITY;
+
+  for (const item of items) {
+    if (item.isLoading || item.error) {
+      continue;
+    }
+
+    const value =
+      metric === 'range'
+        ? item.farthestPoint?.distanceMeters ?? null
+        : metric === 'rssi'
+          ? item.farthestPoint?.rssi ?? null
+          : item.farthestPoint?.snr ?? null;
+
+    if (value === null || !Number.isFinite(value)) {
+      continue;
+    }
+
+    if (!leader || value > leaderValue) {
+      leader = item;
+      leaderValue = value;
+    }
+  }
+
+  if (!leader) {
+    return null;
+  }
+
+  return {
+    label:
+      metric === 'range'
+        ? 'Greatest max range'
+        : metric === 'rssi'
+          ? 'Best edge RSSI'
+          : 'Best edge SNR',
+    sessionLabel: leader.label,
+    value:
+      metric === 'range'
+        ? formatDistanceMeters(leader.farthestPoint?.distanceMeters ?? null)
+        : formatSignalMetric(metric === 'rssi' ? leader.farthestPoint?.rssi : leader.farthestPoint?.snr, metric),
+    color: leader.style.color
+  };
+}
+
+function renderLeaderMetric(items: SessionComparisonItem[], metric: ComparisonLeaderMetric) {
+  const leader = pickComparisonLeader(items, metric);
+
+  return (
+    <div className="session-compare-panel__summary-card">
+      <span className="session-compare-panel__summary-label">
+        {leader?.label ??
+          (metric === 'range'
+            ? 'Greatest max range'
+            : metric === 'rssi'
+              ? 'Best edge RSSI'
+              : 'Best edge SNR')}
+      </span>
+      {leader ? (
+        <>
+          <strong style={{ color: leader.color }}>{leader.value}</strong>
+          <span title={leader.sessionLabel}>{leader.sessionLabel}</span>
+        </>
+      ) : (
+        <>
+          <strong>—</strong>
+          <span>Unavailable</span>
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function SessionComparisonPanel({
   items,
   onToggleVisibility,
@@ -40,33 +144,47 @@ export default function SessionComparisonPanel({
   }
 
   const visibleCount = items.filter((item) => item.isVisible).length;
+  const hasRangeData = items.some((item) => item.farthestPoint !== null);
 
   return (
-    <section className="session-compare-panel" aria-label="Session comparison">
-      <div className="session-compare-panel__header">
-        <div className="session-compare-panel__header-copy">
-          <h4>Session comparison</h4>
-          <p>
-            Reviewing {items.length} sessions together. Colors match the shared map overlay.
-          </p>
+    <section className="session-compare-panel" aria-label="Compare sessions workspace">
+      <div className="session-compare-panel__workspace">
+        <div className="session-compare-panel__header">
+          <div className="session-compare-panel__header-copy">
+            <span className="session-compare-panel__eyebrow">Compare workspace</span>
+            <h4>Compare Sessions</h4>
+            <p>
+              {items.length} selected
+              {visibleCount !== items.length ? ` · ${visibleCount} visible` : ''}
+            </p>
+          </div>
+          <div className="session-compare-panel__header-actions">
+            <button type="button" className="session-compare-panel__button" onClick={onFitAll}>
+              Fit all
+            </button>
+            <button
+              type="button"
+              className="session-compare-panel__button session-compare-panel__button--danger"
+              onClick={onClearComparison}
+            >
+              Exit compare
+            </button>
+          </div>
         </div>
-        <div className="session-compare-panel__header-actions">
-          <button type="button" className="session-compare-panel__button" onClick={onFitAll}>
-            Fit all
-          </button>
-          <button
-            type="button"
-            className="session-compare-panel__button session-compare-panel__button--danger"
-            onClick={onClearComparison}
-          >
-            Exit compare
-          </button>
+
+        <div className="session-compare-panel__summary-strip">
+          {renderLeaderMetric(items, 'range')}
+          {renderLeaderMetric(items, 'rssi')}
+          {renderLeaderMetric(items, 'snr')}
         </div>
+
+        {!hasRangeData ? (
+          <div className="session-compare-panel__notice">
+            Home/base coordinates are required to rank max range and edge signal.
+          </div>
+        ) : null}
       </div>
-      <div className="session-compare-panel__status">
-        <span>{visibleCount} visible</span>
-        <span>{items.length - visibleCount} hidden</span>
-      </div>
+
       <div className="session-compare-panel__list">
         {items.map((item) => {
           const swatchStyle = {
@@ -77,10 +195,11 @@ export default function SessionComparisonPanel({
             <article
               key={item.id}
               className={`session-compare-panel__item${item.isVisible ? '' : ' is-muted'}`}
+              style={swatchStyle}
             >
               <div className="session-compare-panel__item-top">
                 <div className="session-compare-panel__identity">
-                  <span className="session-compare-panel__swatch" style={swatchStyle} aria-hidden="true" />
+                  <span className="session-compare-panel__swatch" aria-hidden="true" />
                   <div className="session-compare-panel__identity-copy">
                     <strong title={item.label}>{item.label}</strong>
                     <span>{formatSessionTimestamp(item.startedAt)}</span>
@@ -95,6 +214,7 @@ export default function SessionComparisonPanel({
                   Visible
                 </label>
               </div>
+
               {item.error ? (
                 <div className="session-compare-panel__message session-compare-panel__message--error">
                   {item.error}
@@ -102,32 +222,47 @@ export default function SessionComparisonPanel({
               ) : item.isLoading ? (
                 <div className="session-compare-panel__message">Loading comparison data…</div>
               ) : (
-                <dl className="session-compare-panel__metrics">
-                  <div>
-                    <dt>Duration</dt>
-                    <dd>{formatSessionDuration(item.durationMs)}</dd>
+                <>
+                  <div className="session-compare-panel__headline">
+                    <span className="session-compare-panel__headline-label">Max range</span>
+                    <strong>{formatDistanceMeters(item.farthestPoint?.distanceMeters ?? null)}</strong>
+                    <span>{formatSessionTimestamp(item.farthestPoint?.capturedAt ?? null)}</span>
                   </div>
-                  <div>
-                    <dt>Points</dt>
-                    <dd>
-                      {item.measurementCount !== null && item.measurementCount !== undefined
-                        ? item.measurementCount.toLocaleString()
-                        : '—'}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Distance</dt>
-                    <dd>{formatDistanceMeters(item.distanceMeters)}</dd>
-                  </div>
-                  <div>
-                    <dt>Avg RSSI</dt>
-                    <dd>{formatSignalMetric(item.avgRssi, 'rssi')}</dd>
-                  </div>
-                  <div>
-                    <dt>Avg SNR</dt>
-                    <dd>{formatSignalMetric(item.avgSnr, 'snr')}</dd>
-                  </div>
-                </dl>
+                  <dl className="session-compare-panel__metrics">
+                    <div>
+                      <dt>Edge RSSI</dt>
+                      <dd>{formatSignalMetric(item.farthestPoint?.rssi ?? null, 'rssi')}</dd>
+                    </div>
+                    <div>
+                      <dt>Edge SNR</dt>
+                      <dd>{formatSignalMetric(item.farthestPoint?.snr ?? null, 'snr')}</dd>
+                    </div>
+                    <div>
+                      <dt>Last successful</dt>
+                      <dd>{formatDistanceMeters(item.lastRangePoint?.distanceMeters ?? null)}</dd>
+                    </div>
+                    <div>
+                      <dt>Duration</dt>
+                      <dd>{formatSessionDuration(item.durationMs)}</dd>
+                    </div>
+                    <div>
+                      <dt>Measurements</dt>
+                      <dd>{formatMeasurementCount(item.measurementCount)}</dd>
+                    </div>
+                    <div>
+                      <dt>Total distance</dt>
+                      <dd>{formatDistanceMeters(item.distanceMeters)}</dd>
+                    </div>
+                    <div>
+                      <dt>Median RSSI</dt>
+                      <dd>{formatSignalMetric(item.medianRssi, 'rssi')}</dd>
+                    </div>
+                    <div>
+                      <dt>Median SNR</dt>
+                      <dd>{formatSignalMetric(item.medianSnr, 'snr')}</dd>
+                    </div>
+                  </dl>
+                </>
               )}
             </article>
           );

--- a/frontend/src/components/SessionsPanel.tsx
+++ b/frontend/src/components/SessionsPanel.tsx
@@ -17,12 +17,22 @@ import {
   useUpdateSession
 } from '../query/sessions';
 import type { Session } from '../api/types';
+import {
+  MAX_COMPARED_SESSIONS,
+  formatSessionLabel as formatComparisonLabel
+} from '../sessionComparison';
 
 type SessionsPanelProps = {
   deviceId: string | null;
   selectedSessionId: string | null;
+  compareSelectionIds: string[];
+  comparisonActive: boolean;
+  comparisonSelectionDirty: boolean;
   onSelectSessionId: (sessionId: string | null) => void;
   onStartSession: (sessionId: string) => void;
+  onToggleCompareSelection: (sessionId: string) => void;
+  onStartComparison: () => void;
+  onClearCompareSelection: () => void;
 };
 
 const SHOW_ARCHIVED_KEY = 'sessionsShowArchived';
@@ -47,7 +57,7 @@ function formatTimestamp(value?: string | null): string {
 }
 
 function sessionLabel(session: Session): string {
-  return session.name?.trim() || `Session ${session.id.slice(0, 8)}`;
+  return formatComparisonLabel(session);
 }
 
 function activeSessionLabel(session: Session): string {
@@ -66,14 +76,20 @@ function isInteractiveTarget(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) {
     return false;
   }
-  return Boolean(target.closest('button, input, textarea, select, a, [role="menuitem"]'));
+  return Boolean(target.closest('button, input, label, textarea, select, a, [role="menuitem"]'));
 }
 
 export default function SessionsPanel({
   deviceId,
   selectedSessionId,
+  compareSelectionIds,
+  comparisonActive,
+  comparisonSelectionDirty,
   onSelectSessionId,
-  onStartSession
+  onStartSession,
+  onToggleCompareSelection,
+  onStartComparison,
+  onClearCompareSelection
 }: SessionsPanelProps) {
   const [sessionName, setSessionName] = useState('');
   const [showArchived, setShowArchived] = useState<boolean>(() => readStoredShowArchived());
@@ -101,10 +117,18 @@ export default function SessionsPanel({
     () => sessions.find((session) => !session.endedAt) ?? null,
     [sessions]
   );
+  const comparedSelectionSet = useMemo(() => new Set(compareSelectionIds), [compareSelectionIds]);
   const pastSessions = useMemo(
     () => sessions.filter((session) => Boolean(session.endedAt)),
     [sessions]
   );
+  const compareButtonDisabled =
+    compareSelectionIds.length < 2 || (comparisonActive && !comparisonSelectionDirty);
+  const compareButtonLabel = comparisonActive
+    ? comparisonSelectionDirty
+      ? 'Update compare'
+      : 'Comparing'
+    : 'Compare selected';
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -319,6 +343,7 @@ export default function SessionsPanel({
 
   const renderSessionRow = (session: Session, isActive = false) => {
     const isSelected = selectedSessionId === session.id;
+    const isCompared = comparedSelectionSet.has(session.id);
     const isEditing = editingSessionId === session.id;
     const isMenuOpen = openMenuSessionId === session.id;
     const isRowUpdating =
@@ -326,6 +351,9 @@ export default function SessionsPanel({
     const isRowDeleting =
       deleteSessionMutation.isPending && deleteSessionMutation.variables?.id === session.id;
     const disableRowActions = isRowUpdating || isRowDeleting;
+    const compareSelectionFull =
+      comparedSelectionSet.size >= MAX_COMPARED_SESSIONS && !isCompared;
+    const compareToggleDisabled = disableRowActions || session.isArchived || compareSelectionFull;
     const title = isActive ? activeSessionLabel(session) : sessionLabel(session);
     const canSelectRow = !isEditing;
 
@@ -334,7 +362,7 @@ export default function SessionsPanel({
         key={session.id}
         className={`sessions-panel__item ${isSelected ? 'is-selected' : ''} ${
           isEditing ? 'is-editing' : ''
-        }`}
+        } ${isCompared ? 'is-compared' : ''}`}
         role={canSelectRow ? 'button' : undefined}
         tabIndex={canSelectRow ? 0 : undefined}
         aria-label={canSelectRow ? `Select ${title}` : undefined}
@@ -386,6 +414,25 @@ export default function SessionsPanel({
             </span>
           )}
           <div className="sessions-panel__item-actions" data-tour="session-actions">
+            <label
+              className={`sessions-panel__compare-toggle${isCompared ? ' is-active' : ''}`}
+              title={
+                session.isArchived
+                  ? 'Archived sessions are not available for comparison'
+                  : compareSelectionFull
+                    ? `Compare up to ${MAX_COMPARED_SESSIONS} sessions`
+                    : undefined
+              }
+            >
+              <input
+                type="checkbox"
+                checked={isCompared}
+                onChange={() => onToggleCompareSelection(session.id)}
+                disabled={compareToggleDisabled}
+                aria-label={`${isCompared ? 'Remove' : 'Add'} ${title} ${isCompared ? 'from' : 'to'} comparison`}
+              />
+              <span>Compare</span>
+            </label>
             {session.isArchived ? <span className="sessions-panel__badge">Archived</span> : null}
             {hasQueryApiKey ? (
               isEditing ? (
@@ -534,6 +581,42 @@ export default function SessionsPanel({
           </button>
         </div>
       )}
+
+      <div className="sessions-panel__compare-bar" aria-label="Session comparison selection">
+        <div className="sessions-panel__compare-copy">
+          <span className="sessions-panel__compare-eyebrow">Session comparison</span>
+          <strong>
+            {compareSelectionIds.length === 0
+              ? `Select 2-${MAX_COMPARED_SESSIONS} sessions`
+              : `${compareSelectionIds.length} selected`}
+          </strong>
+          <span>
+            {comparisonActive
+              ? comparisonSelectionDirty
+                ? 'Update compare to apply the current selection.'
+                : 'The compare view uses the current selected set.'
+              : `Overlay up to ${MAX_COMPARED_SESSIONS} sessions on the map.`}
+          </span>
+        </div>
+        <div className="sessions-panel__compare-actions">
+          <button
+            type="button"
+            onClick={onStartComparison}
+            disabled={compareButtonDisabled}
+          >
+            {compareButtonLabel}
+          </button>
+          {compareSelectionIds.length > 0 ? (
+            <button
+              type="button"
+              className="sessions-panel__compare-clear"
+              onClick={onClearCompareSelection}
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+      </div>
 
       {error && <div className="sessions-panel__error">Failed to load sessions.</div>}
 

--- a/frontend/src/components/SessionsPanel.tsx
+++ b/frontend/src/components/SessionsPanel.tsx
@@ -100,6 +100,7 @@ export default function SessionsPanel({
   const [deleteTargetSession, setDeleteTargetSession] = useState<Session | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [sessionActionError, setSessionActionError] = useState<string | null>(null);
+  const [sessionListExpanded, setSessionListExpanded] = useState(true);
 
   const { data: sessionsResponse, isLoading, error } = useSessions(deviceId ?? undefined, {
     includeArchived: showArchived
@@ -129,6 +130,13 @@ export default function SessionsPanel({
       ? 'Update compare'
       : 'Comparing'
     : 'Compare selected';
+  const compareBarState = comparisonActive
+    ? 'is-active'
+    : compareSelectionIds.length >= 2
+      ? 'is-ready'
+      : compareSelectionIds.length > 0
+        ? 'is-armed'
+        : '';
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -145,7 +153,12 @@ export default function SessionsPanel({
     setDeleteTargetSession(null);
     setDeleteConfirmText('');
     setSessionActionError(null);
+    setSessionListExpanded(true);
   }, [deviceId]);
+
+  useEffect(() => {
+    setSessionListExpanded(!comparisonActive);
+  }, [comparisonActive]);
 
   const handleStart = () => {
     if (!deviceId || startMutation.isPending) {
@@ -582,20 +595,33 @@ export default function SessionsPanel({
         </div>
       )}
 
-      <div className="sessions-panel__compare-bar" aria-label="Session comparison selection">
+      <div
+        className={`sessions-panel__compare-bar ${compareBarState}`.trim()}
+        aria-label="Session comparison selection"
+      >
         <div className="sessions-panel__compare-copy">
-          <span className="sessions-panel__compare-eyebrow">Session comparison</span>
+          <span className="sessions-panel__compare-eyebrow">
+            {comparisonActive ? 'Compare mode' : 'Session comparison'}
+          </span>
           <strong>
-            {compareSelectionIds.length === 0
-              ? `Select 2-${MAX_COMPARED_SESSIONS} sessions`
-              : `${compareSelectionIds.length} selected`}
+            {comparisonActive
+              ? comparisonSelectionDirty
+                ? `${compareSelectionIds.length} sessions selected for update`
+                : `Comparing ${compareSelectionIds.length} sessions`
+              : compareSelectionIds.length >= 2
+                ? `${compareSelectionIds.length} sessions ready to compare`
+                : compareSelectionIds.length === 1
+                  ? 'Select one more session to compare'
+                  : `Select 2-${MAX_COMPARED_SESSIONS} sessions`}
           </strong>
           <span>
             {comparisonActive
               ? comparisonSelectionDirty
-                ? 'Update compare to apply the current selection.'
-                : 'The compare view uses the current selected set.'
-              : `Overlay up to ${MAX_COMPARED_SESSIONS} sessions on the map.`}
+                ? 'Update compare to replace the active compare set.'
+                : 'Review max range, edge signal, and farthest-point markers together.'
+              : compareSelectionIds.length >= 2
+                ? 'Open a dedicated compare workspace for the selected runs.'
+                : `Choose up to ${MAX_COMPARED_SESSIONS} sessions from the list below.`}
           </span>
         </div>
         <div className="sessions-panel__compare-actions">
@@ -620,12 +646,31 @@ export default function SessionsPanel({
 
       {error && <div className="sessions-panel__error">Failed to load sessions.</div>}
 
-      <div className="sessions-panel__list" aria-live="polite" data-tour="session-list">
-        {isLoading && <div className="sessions-panel__loading">Loading sessions…</div>}
-        {!isLoading && sessions.length === 0 && (
-          <div className="sessions-panel__empty">No sessions yet.</div>
+      <div className={`sessions-panel__list-shell${comparisonActive ? ' is-compare-mode' : ''}`}>
+        {comparisonActive ? (
+          <button
+            type="button"
+            className="sessions-panel__list-toggle"
+            onClick={() => setSessionListExpanded((current) => !current)}
+            aria-expanded={sessionListExpanded}
+          >
+            <span>Change compared sessions</span>
+            <strong>{sessionListExpanded ? 'Hide list' : 'Show list'}</strong>
+          </button>
+        ) : null}
+        {sessionListExpanded ? (
+          <div className="sessions-panel__list" aria-live="polite" data-tour="session-list">
+            {isLoading && <div className="sessions-panel__loading">Loading sessions…</div>}
+            {!isLoading && sessions.length === 0 && (
+              <div className="sessions-panel__empty">No sessions yet.</div>
+            )}
+            {pastSessions.map((session) => renderSessionRow(session))}
+          </div>
+        ) : (
+          <div className="sessions-panel__list-collapsed">
+            Session list collapsed while compare mode is active.
+          </div>
         )}
-        {pastSessions.map((session) => renderSessionRow(session))}
       </div>
       {sessionActionError ? (
         <div className="sessions-panel__error" role="status">

--- a/frontend/src/sessionComparison.ts
+++ b/frontend/src/sessionComparison.ts
@@ -1,0 +1,131 @@
+import type { Session, SessionStats } from './api/types';
+
+export const MAX_COMPARED_SESSIONS = 4;
+const COMPARISON_STYLE_PALETTE = [
+  { color: '#38bdf8', dashArray: undefined },
+  { color: '#fb7185', dashArray: '10 8' },
+  { color: '#f59e0b', dashArray: '4 8' },
+  { color: '#34d399', dashArray: '16 8 4 8' }
+] as const;
+
+export type SessionComparisonStyle = {
+  color: string;
+  dashArray?: string;
+};
+
+export function parseComparedSessionIds(value: string | null | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return normalizeComparedSessionIds(value.split(','));
+}
+
+export function normalizeComparedSessionIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const rawId of ids) {
+    const id = rawId.trim();
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    normalized.push(id);
+    if (normalized.length >= MAX_COMPARED_SESSIONS) {
+      break;
+    }
+  }
+
+  return normalized;
+}
+
+export function getSessionComparisonStyle(index: number): SessionComparisonStyle {
+  const style = COMPARISON_STYLE_PALETTE[index % COMPARISON_STYLE_PALETTE.length];
+  return {
+    color: style.color,
+    dashArray: style.dashArray
+  };
+}
+
+export function areStringListsEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((value, index) => value === right[index]);
+}
+
+export function formatSessionLabel(session: Pick<Session, 'id' | 'name'> | { id: string; name?: string | null }): string {
+  return session.name?.trim() || `Session ${session.id.slice(0, 8)}`;
+}
+
+export function formatSessionTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return '—';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
+}
+
+export function buildSessionDurationMs(
+  session: Pick<Session, 'startedAt' | 'endedAt'> | null,
+  stats: Pick<SessionStats, 'minCapturedAt' | 'maxCapturedAt'> | null
+): number | null {
+  const startIso = stats?.minCapturedAt ?? session?.startedAt ?? null;
+  const endIso = stats?.maxCapturedAt ?? session?.endedAt ?? null;
+  if (!startIso || !endIso) {
+    return null;
+  }
+
+  const startMs = new Date(startIso).getTime();
+  const endMs = new Date(endIso).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return null;
+  }
+
+  return endMs - startMs;
+}
+
+export function formatSessionDuration(durationMs: number | null): string {
+  if (durationMs === null || !Number.isFinite(durationMs)) {
+    return '—';
+  }
+
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function formatDistanceMeters(distanceMeters: number | null | undefined): string {
+  if (distanceMeters === null || distanceMeters === undefined || !Number.isFinite(distanceMeters)) {
+    return '—';
+  }
+
+  if (distanceMeters >= 1000) {
+    return `${(distanceMeters / 1000).toFixed(1)} km`;
+  }
+
+  return `${Math.round(distanceMeters)} m`;
+}
+
+export function formatSignalMetric(
+  value: number | null | undefined,
+  metric: 'rssi' | 'snr'
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '—';
+  }
+
+  return metric === 'rssi' ? `${Math.round(value)} dBm` : `${value.toFixed(1)} dB`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loramapr-backend",
-  "version": "0.10.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loramapr-backend",
-      "version": "0.10.3",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@nestjs/common": "^11.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loramapr-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backend API for LoRaMapr, a Meshtastic app for mapping real-world coverage.",

--- a/src/modules/sessions/sessions.service.ts
+++ b/src/modules/sessions/sessions.service.ts
@@ -9,6 +9,7 @@ type SignalSummary = {
   min: number | null;
   max: number | null;
   avg: number | null;
+  median: number | null;
 };
 
 type SignalSeriesMetric = 'rssi' | 'snr';
@@ -17,6 +18,28 @@ type SignalSeriesResolvedSource = Exclude<SignalSeriesSource, 'auto'>;
 type SignalSeriesItem = { t: string; v: number };
 type RawSignalRow = { t: Date; v: number | Prisma.Decimal | null };
 type SignalHistogramBin = { lo: number; hi: number; count: number };
+type SignalSummarySource = SignalSeriesResolvedSource | null;
+type SessionSignalPoint = {
+  measurementId: string;
+  capturedAt: Date;
+  lat: number;
+  lon: number;
+  rssi: number | null;
+  snr: number | null;
+};
+type SessionRangePointSummary = {
+  capturedAt: string;
+  lat: number;
+  lon: number;
+  distanceMeters: number;
+  rssi: number | null;
+  snr: number | null;
+};
+type SessionHomeSummary = {
+  lat: number;
+  lon: number;
+  radiusMeters: number;
+};
 
 @Injectable()
 export class SessionsService {
@@ -359,9 +382,9 @@ export class SessionsService {
           }
         : null;
 
-    const [distanceMeters, signalSummary] = await Promise.all([
+    const [distanceMeters, comparisonSummary] = await Promise.all([
       this.computeDistanceMeters(id, pointCount),
-      this.computeSignalSummary(id)
+      this.computeComparisonSummary(id, session.deviceId)
     ]);
 
     return {
@@ -374,9 +397,13 @@ export class SessionsService {
       pointCount,
       distanceMeters,
       bbox,
-      rssi: signalSummary.rssi,
-      snr: signalSummary.snr,
-      receiversCount: signalSummary.receiversCount
+      home: comparisonSummary.home,
+      farthestPoint: comparisonSummary.farthestPoint,
+      lastRangePoint: comparisonSummary.lastRangePoint,
+      rssi: comparisonSummary.rssi,
+      snr: comparisonSummary.snr,
+      signalSourceUsed: comparisonSummary.sourceUsed,
+      receiversCount: comparisonSummary.receiversCount
     };
   }
 
@@ -566,126 +593,196 @@ export class SessionsService {
     return Number.isFinite(total) ? total : null;
   }
 
-  private async computeSignalSummary(sessionId: string): Promise<{
+  private async computeComparisonSummary(sessionId: string, deviceId: string): Promise<{
+    home: SessionHomeSummary | null;
+    farthestPoint: SessionRangePointSummary | null;
+    lastRangePoint: SessionRangePointSummary | null;
     rssi: SignalSummary | null;
     snr: SignalSummary | null;
+    sourceUsed: SignalSummarySource;
     receiversCount: number | null;
   }> {
-    const meshtasticAggregate = await this.prisma.meshtasticRx.aggregate({
-      where: {
-        measurement: { sessionId }
-      },
-      _count: { _all: true },
-      _min: {
-        rxRssi: true,
-        rxSnr: true
-      },
-      _max: {
-        rxRssi: true,
-        rxSnr: true
-      },
-      _avg: {
-        rxRssi: true,
-        rxSnr: true
+    const [home, sourceUsed] = await Promise.all([
+      this.readSessionHomeSummary(deviceId),
+      this.resolveSignalSummarySource(sessionId)
+    ]);
+    const signalPoints = await this.readSessionSignalPoints(sessionId, sourceUsed);
+    const rssiValues = signalPoints
+      .map((point) => point.rssi)
+      .filter((value): value is number => value !== null && Number.isFinite(value));
+    const snrValues = signalPoints
+      .map((point) => point.snr)
+      .filter((value): value is number => value !== null && Number.isFinite(value));
+    const [receiversCount, farthestPoint, lastRangePoint] = await Promise.all([
+      this.readReceiversCount(sessionId, sourceUsed),
+      Promise.resolve(buildSessionRangeSummaryPoint(signalPoints, home, 'farthest')),
+      Promise.resolve(buildSessionRangeSummaryPoint(signalPoints, home, 'last'))
+    ]);
+
+    return {
+      home,
+      farthestPoint,
+      lastRangePoint,
+      rssi: buildSignalSummary(rssiValues),
+      snr: buildSignalSummary(snrValues),
+      sourceUsed,
+      receiversCount
+    };
+  }
+
+  private async readSessionHomeSummary(deviceId: string): Promise<SessionHomeSummary | null> {
+    const config = await this.prisma.deviceAutoSessionConfig.findUnique({
+      where: { deviceId },
+      select: {
+        homeLat: true,
+        homeLon: true,
+        radiusMeters: true
       }
     });
 
-    if (meshtasticAggregate._count._all > 0) {
-      const receivers = await this.prisma.measurement.groupBy({
-        by: ['gatewayId'],
-        where: {
-          sessionId,
-          gatewayId: { not: null }
-        }
-      });
-
-      return {
-        rssi: toSignalSummary(
-          meshtasticAggregate._min.rxRssi,
-          meshtasticAggregate._max.rxRssi,
-          meshtasticAggregate._avg.rxRssi
-        ),
-        snr: toSignalSummary(
-          meshtasticAggregate._min.rxSnr,
-          meshtasticAggregate._max.rxSnr,
-          meshtasticAggregate._avg.rxSnr
-        ),
-        receiversCount: receivers.length > 0 ? receivers.length : null
-      };
+    if (
+      !config ||
+      typeof config.homeLat !== 'number' ||
+      !Number.isFinite(config.homeLat) ||
+      typeof config.homeLon !== 'number' ||
+      !Number.isFinite(config.homeLon) ||
+      typeof config.radiusMeters !== 'number' ||
+      !Number.isFinite(config.radiusMeters) ||
+      config.radiusMeters <= 0
+    ) {
+      return null;
     }
 
-    const lorawanAggregate = await this.prisma.rxMetadata.aggregate({
-      where: {
-        measurement: { sessionId }
-      },
-      _count: { _all: true },
-      _min: {
-        rssi: true,
-        snr: true
-      },
-      _max: {
-        rssi: true,
-        snr: true
-      },
-      _avg: {
+    return {
+      lat: config.homeLat,
+      lon: config.homeLon,
+      radiusMeters: config.radiusMeters
+    };
+  }
+
+  private async resolveSignalSummarySource(sessionId: string): Promise<SignalSummarySource> {
+    const [meshtasticCount, lorawanCount, measurementCount] = await Promise.all([
+      this.prisma.meshtasticRx.count({
+        where: {
+          measurement: { sessionId }
+        }
+      }),
+      this.prisma.rxMetadata.count({
+        where: {
+          measurement: { sessionId }
+        }
+      }),
+      this.prisma.measurement.count({
+        where: {
+          sessionId,
+          OR: [{ rssi: { not: null } }, { snr: { not: null } }]
+        }
+      })
+    ]);
+
+    if (meshtasticCount > 0) {
+      return 'meshtastic';
+    }
+    if (lorawanCount > 0) {
+      return 'lorawan';
+    }
+    if (measurementCount > 0) {
+      return 'measurement';
+    }
+    return null;
+  }
+
+  private async readSessionSignalPoints(
+    sessionId: string,
+    source: SignalSummarySource
+  ): Promise<SessionSignalPoint[]> {
+    if (source === 'meshtastic') {
+      return this.prisma.$queryRaw<SessionSignalPoint[]>(
+        Prisma.sql`
+          SELECT
+            m."id" AS "measurementId",
+            m."capturedAt",
+            m."lat",
+            m."lon",
+            mx."rxRssi" AS "rssi",
+            mx."rxSnr" AS "snr"
+          FROM "Measurement" m
+          LEFT JOIN "MeshtasticRx" mx ON mx."measurementId" = m."id"
+          WHERE m."sessionId" = ${sessionId}::uuid
+          ORDER BY m."capturedAt" ASC, m."id" ASC
+        `
+      );
+    }
+
+    if (source === 'lorawan') {
+      return this.prisma.$queryRaw<SessionSignalPoint[]>(
+        Prisma.sql`
+          WITH ranked AS (
+            SELECT
+              m."id" AS "measurementId",
+              m."capturedAt",
+              m."lat",
+              m."lon",
+              rx."rssi",
+              rx."snr",
+              row_number() OVER (
+                PARTITION BY m."id"
+                ORDER BY rx."snr" DESC NULLS LAST, rx."rssi" DESC NULLS LAST, rx."gatewayId" ASC
+              ) AS rn
+            FROM "Measurement" m
+            LEFT JOIN "RxMetadata" rx ON rx."measurementId" = m."id"
+            WHERE m."sessionId" = ${sessionId}::uuid
+          )
+          SELECT
+            "measurementId",
+            "capturedAt",
+            "lat",
+            "lon",
+            "rssi",
+            "snr"
+          FROM ranked
+          WHERE rn = 1
+          ORDER BY "capturedAt" ASC, "measurementId" ASC
+        `
+      );
+    }
+
+    return this.prisma.measurement.findMany({
+      where: { sessionId },
+      orderBy: [{ capturedAt: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        capturedAt: true,
+        lat: true,
+        lon: true,
         rssi: true,
         snr: true
       }
-    });
+    }).then((rows) =>
+      rows.map((row) => ({
+        measurementId: row.id,
+        capturedAt: row.capturedAt,
+        lat: row.lat,
+        lon: row.lon,
+        rssi: row.rssi,
+        snr: row.snr
+      }))
+    );
+  }
 
-    if (lorawanAggregate._count._all > 0) {
+  private async readReceiversCount(
+    sessionId: string,
+    source: SignalSummarySource
+  ): Promise<number | null> {
+    if (source === 'lorawan') {
       const receivers = await this.prisma.rxMetadata.groupBy({
         by: ['gatewayId'],
         where: {
           measurement: { sessionId }
         }
       });
-
-      return {
-        rssi: toSignalSummary(
-          lorawanAggregate._min.rssi,
-          lorawanAggregate._max.rssi,
-          lorawanAggregate._avg.rssi
-        ),
-        snr: toSignalSummary(
-          lorawanAggregate._min.snr,
-          lorawanAggregate._max.snr,
-          lorawanAggregate._avg.snr
-        ),
-        receiversCount: receivers.length > 0 ? receivers.length : null
-      };
+      return receivers.length > 0 ? receivers.length : null;
     }
-
-    const fallbackSignalCount = await this.prisma.measurement.count({
-      where: {
-        sessionId,
-        OR: [{ rssi: { not: null } }, { snr: { not: null } }]
-      }
-    });
-
-    if (fallbackSignalCount === 0) {
-      return {
-        rssi: null,
-        snr: null,
-        receiversCount: null
-      };
-    }
-
-    const fallbackAggregate = await this.prisma.measurement.aggregate({
-      where: { sessionId },
-      _min: {
-        rssi: true,
-        snr: true
-      },
-      _max: {
-        rssi: true,
-        snr: true
-      },
-      _avg: {
-        rssi: true,
-        snr: true
-      }
-    });
 
     const receivers = await this.prisma.measurement.groupBy({
       by: ['gatewayId'],
@@ -694,20 +791,7 @@ export class SessionsService {
         gatewayId: { not: null }
       }
     });
-
-    return {
-      rssi: toSignalSummary(
-        fallbackAggregate._min.rssi,
-        fallbackAggregate._max.rssi,
-        fallbackAggregate._avg.rssi
-      ),
-      snr: toSignalSummary(
-        fallbackAggregate._min.snr,
-        fallbackAggregate._max.snr,
-        fallbackAggregate._avg.snr
-      ),
-      receiversCount: receivers.length > 0 ? receivers.length : null
-    };
+    return receivers.length > 0 ? receivers.length : null;
   }
 
   private async resolveSignalSeriesSource(
@@ -973,22 +1057,122 @@ function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number)
   return earthRadiusMeters * c;
 }
 
-function toSignalSummary(
-  min: number | Prisma.Decimal | null | undefined,
-  max: number | Prisma.Decimal | null | undefined,
-  avg: number | Prisma.Decimal | null | undefined
-): SignalSummary | null {
-  const minValue = toNumeric(min);
-  const maxValue = toNumeric(max);
-  const avgValue = toNumeric(avg);
-  if (minValue === null && maxValue === null && avgValue === null) {
+function buildSessionRangeSummaryPoint(
+  points: SessionSignalPoint[],
+  home: SessionHomeSummary | null,
+  mode: 'farthest' | 'last'
+): SessionRangePointSummary | null {
+  if (!home || points.length === 0) {
     return null;
   }
+
+  let selected:
+    | {
+        point: SessionSignalPoint;
+        distanceMeters: number;
+      }
+    | null = null;
+
+  for (const point of points) {
+    if (
+      !Number.isFinite(point.lat) ||
+      !Number.isFinite(point.lon)
+    ) {
+      continue;
+    }
+
+    const distanceMeters = haversineMeters(home.lat, home.lon, point.lat, point.lon);
+    if (!Number.isFinite(distanceMeters)) {
+      continue;
+    }
+
+    if (mode === 'last') {
+      selected = {
+        point,
+        distanceMeters
+      };
+      continue;
+    }
+
+    if (!selected || distanceMeters > selected.distanceMeters) {
+      selected = {
+        point,
+        distanceMeters
+      };
+      continue;
+    }
+
+    if (distanceMeters === selected.distanceMeters) {
+      const selectedTime = selected.point.capturedAt.getTime();
+      const candidateTime = point.capturedAt.getTime();
+      if (candidateTime >= selectedTime) {
+        selected = {
+          point,
+          distanceMeters
+        };
+      }
+    }
+  }
+
+  if (!selected) {
+    return null;
+  }
+
   return {
-    min: minValue,
-    max: maxValue,
-    avg: avgValue
+    capturedAt: selected.point.capturedAt.toISOString(),
+    lat: selected.point.lat,
+    lon: selected.point.lon,
+    distanceMeters: selected.distanceMeters,
+    rssi:
+      typeof selected.point.rssi === 'number' && Number.isFinite(selected.point.rssi)
+        ? selected.point.rssi
+        : null,
+    snr:
+      typeof selected.point.snr === 'number' && Number.isFinite(selected.point.snr)
+        ? selected.point.snr
+        : null
   };
+}
+
+function buildSignalSummary(values: number[]): SignalSummary | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+
+  for (const value of values) {
+    if (value < min) {
+      min = value;
+    }
+    if (value > max) {
+      max = value;
+    }
+    sum += value;
+  }
+
+  return {
+    min,
+    max,
+    avg: sum / values.length,
+    median: computeMedian(values)
+  };
+}
+
+function computeMedian(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  const middleIndex = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middleIndex];
+  }
+
+  return (sorted[middleIndex - 1] + sorted[middleIndex]) / 2;
 }
 
 function toNumeric(value: number | Prisma.Decimal | null | undefined): number | null {

--- a/test/sessions.e2e-spec.ts
+++ b/test/sessions.e2e-spec.ts
@@ -33,6 +33,18 @@ describe('Sessions e2e', () => {
     });
     deviceId = device.id;
 
+    await prisma.deviceAutoSessionConfig.create({
+      data: {
+        deviceId,
+        enabled: true,
+        homeLat: 37.7695,
+        homeLon: -122.4295,
+        radiusMeters: 50,
+        minOutsideSeconds: 30,
+        minInsideSeconds: 120
+      }
+    });
+
     const session = await prisma.session.create({
       data: {
         deviceId,
@@ -124,10 +136,19 @@ describe('Sessions e2e', () => {
   });
 
   afterAll(async () => {
-    await prisma.measurement.deleteMany({ where: { sessionId: { in: [sessionId, signalSessionId] } } });
-    await prisma.session.deleteMany({ where: { id: { in: [sessionId, signalSessionId] } } });
-    await prisma.device.deleteMany({ where: { id: deviceId } });
-    await app.close();
+    if (prisma && deviceId) {
+      await prisma.deviceAutoSessionConfig.deleteMany({ where: { deviceId } });
+    }
+    if (prisma && (sessionId || signalSessionId)) {
+      await prisma.measurement.deleteMany({ where: { sessionId: { in: [sessionId, signalSessionId] } } });
+      await prisma.session.deleteMany({ where: { id: { in: [sessionId, signalSessionId] } } });
+    }
+    if (prisma && deviceId) {
+      await prisma.device.deleteMany({ where: { id: deviceId } });
+    }
+    if (app) {
+      await app.close();
+    }
   });
 
   it('timeline returns min/max/count for a session', async () => {
@@ -198,8 +219,65 @@ describe('Sessions e2e', () => {
       maxLat: 37.771,
       maxLon: -122.43
     });
+    expect(response.body.home).toEqual({
+      lat: 37.7695,
+      lon: -122.4295,
+      radiusMeters: 50
+    });
+    expect(response.body.farthestPoint).toMatchObject({
+      capturedAt: timestamps.t2.toISOString(),
+      lat: 37.771,
+      lon: -122.431,
+      rssi: null,
+      snr: null
+    });
+    expect(response.body.farthestPoint.distanceMeters).toEqual(expect.any(Number));
+    expect(response.body.farthestPoint.distanceMeters).toBeGreaterThan(0);
+    expect(response.body.lastRangePoint).toMatchObject({
+      capturedAt: timestamps.t2.toISOString(),
+      lat: 37.771,
+      lon: -122.431,
+      rssi: null,
+      snr: null
+    });
     expect(response.body.rssi).toBeNull();
     expect(response.body.snr).toBeNull();
+    expect(response.body.signalSourceUsed).toBeNull();
+    expect(response.body.receiversCount).toBeNull();
+  });
+
+  it('stats returns range and edge signal summaries for signal sessions', async () => {
+    const response = await request(app.getHttpServer())
+      .get(`/api/sessions/${signalSessionId}/stats`)
+      .expect(200);
+
+    expect(response.body.sessionId).toBe(signalSessionId);
+    expect(response.body.pointCount).toBe(3);
+    expect(response.body.farthestPoint).toMatchObject({
+      capturedAt: signalTimestamps.t2.toISOString(),
+      lat: 37.7713,
+      lon: -122.4313,
+      rssi: -100,
+      snr: 0
+    });
+    expect(response.body.lastRangePoint).toMatchObject({
+      capturedAt: signalTimestamps.t2.toISOString(),
+      lat: 37.7713,
+      lon: -122.4313,
+      rssi: -100,
+      snr: 0
+    });
+    expect(response.body.rssi).toEqual({
+      min: -120,
+      max: -100,
+      avg: -110,
+      median: -110
+    });
+    expect(response.body.snr.min).toBe(-5);
+    expect(response.body.snr.max).toBe(0);
+    expect(response.body.snr.avg).toBeCloseTo(-8 / 3, 6);
+    expect(response.body.snr.median).toBe(-3);
+    expect(response.body.signalSourceUsed).toBe('measurement');
     expect(response.body.receiversCount).toBeNull();
   });
 

--- a/test/sessions.e2e-spec.ts
+++ b/test/sessions.e2e-spec.ts
@@ -158,6 +158,26 @@ describe('Sessions e2e', () => {
     expect(response.body.items[0].capturedAt).toBe(cursor);
   });
 
+  it('overview returns a sampled full-session track', async () => {
+    const response = await request(app.getHttpServer())
+      .get(`/api/sessions/${sessionId}/overview?sample=2`)
+      .expect(200);
+
+    expect(response.body.sessionId).toBe(sessionId);
+    expect(response.body.items).toEqual([
+      {
+        capturedAt: timestamps.t0.toISOString(),
+        lat: 37.77,
+        lon: -122.43
+      },
+      {
+        capturedAt: timestamps.t2.toISOString(),
+        lat: 37.771,
+        lon: -122.431
+      }
+    ]);
+  });
+
   it('stats returns aggregate session metrics', async () => {
     const response = await request(app.getHttpServer())
       .get(`/api/sessions/${sessionId}/stats`)


### PR DESCRIPTION
## Summary
- add the production-usable session comparison workflow
- refine compare mode around max range and edge signal outcomes
- bump root/frontend versions to 1.2.0 and add release notes/changelog updates

## Verification
- npm --prefix frontend exec -- tsc --noEmit
- npm --prefix frontend run build
- npm run build
- targeted session e2e remains blocked by the existing local Prisma/Nest bootstrap issue during RetentionService startup