### PR TITLE
feat(events): recover sessions from selected Events range

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2792,7 +2792,7 @@
 
 .events-explorer__virtual-row {
   display: grid;
-  grid-template-columns: minmax(7.6rem, 1.2fr) minmax(4.2rem, 0.7fr) minmax(7.2rem, 1.3fr) minmax(
+  grid-template-columns: minmax(3.4rem, 0.5fr) minmax(7.6rem, 1.2fr) minmax(4.2rem, 0.7fr) minmax(7.2rem, 1.3fr) minmax(
       5.4rem,
       0.9fr
     ) minmax(4rem, 0.65fr) minmax(4rem, 0.65fr) minmax(11rem, 2fr);
@@ -2840,6 +2840,54 @@
 
 .events-explorer__row.is-selected {
   background: var(--accent-bg-soft);
+}
+
+.events-explorer__row.is-range-selected {
+  background: color-mix(in srgb, var(--accent-bg-soft) 48%, transparent);
+}
+
+.events-explorer__virtual-row input[type='checkbox'] {
+  width: 0.82rem;
+  height: 0.82rem;
+  margin: 0;
+}
+
+.events-explorer__recovery-toast {
+  padding: 0.42rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--ok, #22c55e) 45%, var(--border-soft));
+  background: color-mix(in srgb, var(--ok, #22c55e) 16%, transparent);
+  color: var(--panel-text);
+  font-size: 0.66rem;
+  font-family: var(--font-mono);
+}
+
+.events-explorer__recovery-bar {
+  display: grid;
+  gap: 0.35rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border-soft));
+  border-radius: 8px;
+  padding: 0.4rem 0.5rem;
+  background: color-mix(in srgb, var(--accent-bg-soft) 54%, transparent);
+}
+
+.events-explorer__recovery-meta {
+  font-size: 0.64rem;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.events-explorer__recovery-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.events-explorer__recover-button {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border-strong));
+  background: color-mix(in srgb, var(--accent-bg-soft) 62%, var(--panel-surface));
 }
 
 .events-explorer__empty {
@@ -2898,6 +2946,136 @@
   border-color: var(--danger-border);
   background: var(--danger-bg);
   color: var(--danger-fg);
+}
+
+.events-explorer__modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: color-mix(in srgb, black 35%, transparent);
+}
+
+.events-explorer__modal {
+  width: min(620px, 100%);
+  display: grid;
+  gap: 0.5rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-strong);
+  background: var(--panel-bg);
+  padding: 0.75rem;
+  box-shadow: 0 18px 44px color-mix(in srgb, black 42%, transparent);
+}
+
+.events-explorer__modal h4 {
+  margin: 0;
+  font-size: 0.74rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--panel-muted);
+  font-family: var(--font-mono);
+}
+
+.events-explorer__modal-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.events-explorer__modal-summary > div {
+  display: grid;
+  gap: 0.16rem;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--panel-surface);
+  padding: 0.33rem 0.42rem;
+}
+
+.events-explorer__modal-summary span {
+  color: var(--panel-muted);
+  font-size: 0.56rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+
+.events-explorer__modal-summary strong {
+  color: var(--panel-text);
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.events-explorer__modal-field {
+  display: grid;
+  gap: 0.25rem;
+  color: var(--panel-muted);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+
+.events-explorer__modal-field input,
+.events-explorer__modal-field textarea {
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  background: var(--panel-surface);
+  color: var(--panel-text);
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  padding: 0.44rem 0.5rem;
+}
+
+.events-explorer__modal-field textarea {
+  resize: vertical;
+}
+
+.events-explorer__modal-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.2rem;
+  color: var(--panel-text);
+  font-size: 0.66rem;
+  font-family: var(--font-mono);
+}
+
+.events-explorer__modal-list--blocking {
+  color: var(--danger-fg);
+}
+
+.events-explorer__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.events-explorer__modal-cancel,
+.events-explorer__modal-confirm {
+  border-radius: 7px;
+  border: 1px solid var(--border-strong);
+  background: var(--panel-surface);
+  color: var(--panel-text);
+  font-size: 0.62rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  padding: 0.3rem 0.58rem;
+}
+
+.events-explorer__modal-confirm {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border-strong));
+  background: color-mix(in srgb, var(--accent-bg-soft) 58%, var(--panel-surface));
+}
+
+.events-explorer__modal-cancel:disabled,
+.events-explorer__modal-confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .events-explorer__drawer {
@@ -3306,6 +3484,10 @@
   }
 
   .events-explorer__highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .events-explorer__modal-summary {
     grid-template-columns: 1fr;
   }
 
@@ -3990,7 +4172,7 @@
   }
 
   .events-explorer__virtual-row {
-    grid-template-columns: repeat(7, minmax(0, 1fr));
+    grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 
   .events-explorer__virtual-row > div {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import type {
   CoverageBin,
   Measurement,
+  RecoverSessionFromEventsResult,
   Session,
   SessionWindowPoint,
   UnifiedEventListItem
@@ -1253,6 +1254,22 @@ function App() {
   const handleSessionStart = (sessionId: string) => {
     handleFilterModeChange('session');
     setSelectedSessionId(sessionId);
+  };
+
+  const handleOpenRecoveredSession = (result: RecoverSessionFromEventsResult) => {
+    handleFilterModeChange('session');
+    if (result.deviceId) {
+      setDeviceId(result.deviceId);
+    }
+    setSelectedSessionId(result.sessionId);
+    setSidebarTab('sessions');
+    setViewMode('explore');
+    setPlaybackIsPlaying(false);
+    setMapLayerMode('points');
+    setSelectedPointId(null);
+    setSessionSelectionNotice(
+      `Recovered session created (${result.attachedEventCount} events attached).`
+    );
   };
 
   const handleToggleCompareSelection = useCallback((sessionId: string) => {
@@ -3395,6 +3412,7 @@ function App() {
       eventsNavigationRequest={eventsNavigationRequest}
       onOpenEvents={handleOpenEvents}
       onSelectEventForMap={handleSelectEventForMap}
+      onOpenRecoveredSession={handleOpenRecoveredSession}
     />
   );
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -273,11 +273,18 @@ function buildHomeGeofenceStorageKey(deviceId: string): string {
   return `${SHOW_HOME_GEOFENCE_PREFIX}${deviceId}`;
 }
 
-function readStoredShowHomeGeofence(deviceId: string | null): boolean {
+function readStoredShowHomeGeofence(deviceId: string | null): boolean | null {
   if (typeof window === 'undefined' || !deviceId) {
+    return null;
+  }
+  const raw = window.localStorage.getItem(buildHomeGeofenceStorageKey(deviceId));
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
     return false;
   }
-  return window.localStorage.getItem(buildHomeGeofenceStorageKey(deviceId)) === 'true';
+  return null;
 }
 
 function readStoredBoolean(key: string): boolean {
@@ -801,7 +808,7 @@ function App() {
     readStoredShowCoverageTracks()
   );
   const [showDeviceMarkers, setShowDeviceMarkers] = useState<boolean>(() => readStoredShowDeviceMarkers());
-  const [showHomeGeofence, setShowHomeGeofence] = useState<boolean>(() =>
+  const [showHomeGeofenceOverride, setShowHomeGeofenceOverride] = useState<boolean | null>(() =>
     readStoredShowHomeGeofence(initial.deviceId)
   );
   const [pointDetailsCollapsed, setPointDetailsCollapsed] = useState<boolean>(() =>
@@ -1002,18 +1009,8 @@ function App() {
   }, [showCoverageTracks]);
 
   useEffect(() => {
-    setShowHomeGeofence(readStoredShowHomeGeofence(deviceId));
+    setShowHomeGeofenceOverride(readStoredShowHomeGeofence(deviceId));
   }, [deviceId]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !deviceId) {
-      return;
-    }
-    window.localStorage.setItem(
-      buildHomeGeofenceStorageKey(deviceId),
-      showHomeGeofence ? 'true' : 'false'
-    );
-  }, [deviceId, showHomeGeofence]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -2450,6 +2447,17 @@ function App() {
   ]);
   const latestMeasurementAt =
     latestDeviceQuery.data?.latestMeasurementAt ?? selectedDevice?.latestMeasurementAt ?? null;
+  const showHomeGeofence = showHomeGeofenceOverride ?? (autoSessionQuery.data?.enabled === true);
+  const handleShowHomeGeofenceChange = useCallback(
+    (value: boolean) => {
+      setShowHomeGeofenceOverride(value);
+      if (typeof window === 'undefined' || !deviceId) {
+        return;
+      }
+      window.localStorage.setItem(buildHomeGeofenceStorageKey(deviceId), value ? 'true' : 'false');
+    },
+    [deviceId]
+  );
   const homeGeofenceConfig = useMemo(() => {
     const config = autoSessionQuery.data;
     if (!config) {
@@ -3366,7 +3374,7 @@ function App() {
       onShowDeviceMarkersChange={setShowDeviceMarkers}
       showHomeGeofence={showHomeGeofence}
       homeGeofenceConfigured={isHomeGeofenceConfigured}
-      onShowHomeGeofenceChange={setShowHomeGeofence}
+      onShowHomeGeofenceChange={handleShowHomeGeofenceChange}
       onShowPointsChange={setShowPoints}
       onShowTrackChange={setShowTrack}
       onShowCoverageTracksChange={setShowCoverageTracks}

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -30,7 +30,9 @@ import type {
   SystemStatus,
   UnifiedEventDetail,
   UnifiedEventsResponse,
-  UnifiedEventSource
+  UnifiedEventSource,
+  RecoverSessionFromEventsPreview,
+  RecoverSessionFromEventsResult
 } from './types';
 
 export type Bbox = {
@@ -741,4 +743,26 @@ export async function getUnifiedEventById(
   options?: RequestOptions
 ): Promise<UnifiedEventDetail> {
   return getJson<UnifiedEventDetail>(`/api/events/${id}`, withQueryApiKey(options));
+}
+
+export async function previewSessionRecoveryFromEvents(
+  input: { eventIds: string[] },
+  options?: RequestOptions
+): Promise<RecoverSessionFromEventsPreview> {
+  return requestJson<RecoverSessionFromEventsPreview>('/api/events/recover-session/preview', {
+    method: 'POST',
+    json: input,
+    ...withQueryApiKey(options)
+  });
+}
+
+export async function createSessionFromEventSelection(
+  input: { eventIds: string[]; name?: string; notes?: string },
+  options?: RequestOptions
+): Promise<RecoverSessionFromEventsResult> {
+  return requestJson<RecoverSessionFromEventsResult>('/api/events/recover-session', {
+    method: 'POST',
+    json: input,
+    ...withQueryApiKey(options)
+  });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -440,3 +440,39 @@ export type UnifiedEventDetail = {
   error: string | null;
   payloadJson: unknown;
 };
+
+export type RecoverSessionFromEventsPreview = {
+  selectedEventCount: number;
+  eligibleEventCount: number;
+  eligibleMeasurementCount: number;
+  alreadyAssignedEventCount: number;
+  incompatibleEventCount: number;
+  warningCount: number;
+  warnings: string[];
+  blockingErrors: string[];
+  canCreate: boolean;
+  startTime: string | null;
+  endTime: string | null;
+  durationMs: number | null;
+  inferredDeviceId: string | null;
+  inferredDeviceUid: string | null;
+  inferredDeviceName: string | null;
+  mixedRawDevices: boolean;
+  mixedMeasurementDevices: boolean;
+  hasLargeTimeGap: boolean;
+  maxGapMs: number | null;
+  defaultSessionName: string | null;
+};
+
+export type RecoverSessionFromEventsResult = {
+  sessionId: string;
+  deviceId: string;
+  deviceUid: string | null;
+  sessionName: string | null;
+  selectedEventCount: number;
+  attachedEventCount: number;
+  attachedMeasurementCount: number;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+};

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -13,7 +13,8 @@ import type {
   Session,
   DeviceTelemetrySample,
   SessionStats,
-  UnifiedEventListItem
+  UnifiedEventListItem,
+  RecoverSessionFromEventsResult
 } from '../api/types';
 import { useApiDiagnosticsEntries } from '../api/diagnostics';
 import { ApiError } from '../api/http';
@@ -138,6 +139,7 @@ type ControlsProps = {
   eventsNavigationRequest: EventsNavigationInput | null;
   onOpenEvents: (input: EventsNavigationInput) => void;
   onSelectEventForMap: (event: UnifiedEventListItem) => void;
+  onOpenRecoveredSession: (result: RecoverSessionFromEventsResult) => void;
 };
 
 export default function Controls({
@@ -214,7 +216,8 @@ export default function Controls({
   eventsNavigationNonce,
   eventsNavigationRequest,
   onOpenEvents,
-  onSelectEventForMap
+  onSelectEventForMap,
+  onOpenRecoveredSession
 }: ControlsProps) {
   const { data: devicesData, isLoading } = useDevices();
   const devices = devicesData?.items ?? [];
@@ -1915,6 +1918,7 @@ export default function Controls({
             navigationRequest={eventsNavigationRequest}
             onSelectEventForMap={onSelectEventForMap}
             onDeviceFilterChange={handleEventsDeviceFilterChange}
+            onOpenRecoveredSession={onOpenRecoveredSession}
           />
           <div className="controls__group controls__system-status-panel">
             <span className="controls__label">System status</span>

--- a/frontend/src/components/EventsExplorerPanel.tsx
+++ b/frontend/src/components/EventsExplorerPanel.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { List, type RowComponentProps } from 'react-window';
-import { getUnifiedEventById } from '../api/endpoints';
+import {
+  createSessionFromEventSelection,
+  getUnifiedEventById,
+  previewSessionRecoveryFromEvents
+} from '../api/endpoints';
 import { ApiError } from '../api/http';
 import { useDevices } from '../query/hooks';
 import { useUnifiedEvent, useUnifiedEvents } from '../query/events';
-import type { UnifiedEventDetail, UnifiedEventListItem, UnifiedEventSource } from '../api/types';
+import type {
+  RecoverSessionFromEventsPreview,
+  RecoverSessionFromEventsResult,
+  UnifiedEventDetail,
+  UnifiedEventListItem,
+  UnifiedEventSource
+} from '../api/types';
 import { applyEventsNavigationParams, readEventsNavigationParams } from '../utils/eventsNavigation';
 import type { EventsNavigationInput } from '../utils/eventsNavigation';
 
@@ -16,6 +26,7 @@ type EventsExplorerPanelProps = {
   navigationRequest: EventsNavigationInput | null;
   onSelectEventForMap?: (event: UnifiedEventListItem) => void;
   onDeviceFilterChange?: (deviceUid: string | null) => void;
+  onOpenRecoveredSession?: (result: RecoverSessionFromEventsResult) => void;
 };
 
 type TimePreset = 'last15m' | 'last1h' | 'last24h' | 'custom';
@@ -74,7 +85,16 @@ const TIME_PRESETS: Array<{ value: TimePreset; label: string }> = [
   { value: 'custom', label: 'Custom' }
 ];
 
-const EVENT_COLUMN_HEADERS = ['Time', 'Source', 'Device', 'Portnum', 'rxRssi', 'rxSnr', 'Summary'] as const;
+const EVENT_COLUMN_HEADERS = [
+  'Select',
+  'Time',
+  'Source',
+  'Device',
+  'Portnum',
+  'rxRssi',
+  'rxSnr',
+  'Summary'
+] as const;
 const EVENTS_FILTERS_STORAGE_KEY = 'eventsExplorer:lastFilters:v1';
 const EVENTS_SAVED_VIEWS_STORAGE_KEY = 'eventsExplorer:savedViews:v1';
 const QUICK_PORTNUM_CHIPS = ['POSITION_APP', 'TELEMETRY_APP', 'NODEINFO_APP'] as const;
@@ -260,6 +280,35 @@ function formatTimestamp(value: string | null | undefined): string {
   return parsed.toLocaleString();
 }
 
+function formatDurationLabel(durationMs: number | null | undefined): string {
+  if (typeof durationMs !== 'number' || !Number.isFinite(durationMs) || durationMs < 0) {
+    return '—';
+  }
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function areSameStringArray(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function toDateTimeLocalValue(value: string | undefined): string {
   if (!value) {
     return '';
@@ -314,7 +363,9 @@ function buildRequestId(error: unknown): string | null {
 type EventVirtualRowProps = {
   events: UnifiedEventListItem[];
   selectedEventId: string | null;
-  onSelectEvent: (event: UnifiedEventListItem) => void;
+  selectedRecoveryEventIds: Set<string>;
+  onSelectEvent: (event: UnifiedEventListItem, options?: { shiftKey?: boolean }) => void;
+  onToggleRecoverySelection: (event: UnifiedEventListItem, options?: { shiftKey?: boolean }) => void;
   onPrefetchDetail: (eventId: string) => void;
 };
 
@@ -324,21 +375,24 @@ function EventsVirtualRow({
   style,
   events,
   selectedEventId,
+  selectedRecoveryEventIds,
   onSelectEvent,
+  onToggleRecoverySelection,
   onPrefetchDetail
 }: RowComponentProps<EventVirtualRowProps>) {
   const item = events[index];
   if (!item) {
     return null;
   }
+  const inRecoverySelection = selectedRecoveryEventIds.has(item.id);
   return (
     <div
       style={style}
       {...ariaAttributes}
       role="row"
       aria-selected={selectedEventId === item.id}
-      className={`events-explorer__virtual-row events-explorer__row ${selectedEventId === item.id ? 'is-selected' : ''}`}
-      onClick={() => onSelectEvent(item)}
+      className={`events-explorer__virtual-row events-explorer__row ${selectedEventId === item.id ? 'is-selected' : ''} ${inRecoverySelection ? 'is-range-selected' : ''}`}
+      onClick={(event) => onSelectEvent(item, { shiftKey: event.shiftKey })}
       onMouseEnter={() => onPrefetchDetail(item.id)}
       onFocus={() => onPrefetchDetail(item.id)}
       onKeyDown={(event) => {
@@ -349,6 +403,18 @@ function EventsVirtualRow({
       }}
       tabIndex={0}
     >
+      <div role="cell">
+        <input
+          type="checkbox"
+          checked={inRecoverySelection}
+          readOnly
+          aria-label={`Select event ${item.id} for recovered session`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleRecoverySelection(item, { shiftKey: event.shiftKey });
+          }}
+        />
+      </div>
       <div role="cell">{formatTimestamp(item.receivedAt)}</div>
       <div role="cell">{item.source}</div>
       <div role="cell">{item.deviceUid ?? '—'}</div>
@@ -913,7 +979,8 @@ export default function EventsExplorerPanel({
   navigationNonce,
   navigationRequest,
   onSelectEventForMap,
-  onDeviceFilterChange
+  onDeviceFilterChange,
+  onOpenRecoveredSession
 }: EventsExplorerPanelProps) {
   const queryClient = useQueryClient();
   const [source, setSource] = useState<'' | UnifiedEventSource>('');
@@ -931,6 +998,20 @@ export default function EventsExplorerPanel({
   const [detailSwapPending, setDetailSwapPending] = useState(false);
   const [allowHugePayloadRender, setAllowHugePayloadRender] = useState(false);
   const [copyEventIdState, setCopyEventIdState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [recoverySelectionIds, setRecoverySelectionIds] = useState<string[]>([]);
+  const [recoveryAnchorEventId, setRecoveryAnchorEventId] = useState<string | null>(null);
+  const [recoveryModalOpen, setRecoveryModalOpen] = useState(false);
+  const [recoveryPreview, setRecoveryPreview] = useState<RecoverSessionFromEventsPreview | null>(
+    null
+  );
+  const [recoveryPreviewLoading, setRecoveryPreviewLoading] = useState(false);
+  const [recoveryPreviewError, setRecoveryPreviewError] = useState<string | null>(null);
+  const [recoverySessionName, setRecoverySessionName] = useState('');
+  const [recoverySessionNameEdited, setRecoverySessionNameEdited] = useState(false);
+  const [recoveryNotes, setRecoveryNotes] = useState('');
+  const [recoveryCreatePending, setRecoveryCreatePending] = useState(false);
+  const [recoveryCreateError, setRecoveryCreateError] = useState<string | null>(null);
+  const [recoveryToast, setRecoveryToast] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !isActive) {
@@ -992,6 +1073,12 @@ export default function EventsExplorerPanel({
     setSelectedEventId(requestedEventId || null);
     setDetailEventId(requestedEventId || null);
     setDetailSwapPending(false);
+    setRecoverySelectionIds([]);
+    setRecoveryAnchorEventId(null);
+    setRecoveryModalOpen(false);
+    setRecoveryPreview(null);
+    setRecoveryPreviewError(null);
+    setRecoveryCreateError(null);
   }, [navigationNonce, navigationRequest, isActive]);
 
   const devicesQuery = useDevices(true, { enabled: isActive && hasQueryApiKey });
@@ -1005,7 +1092,14 @@ export default function EventsExplorerPanel({
     Number(quickFilters.hasTelemetry) +
     Number(quickFilters.hasNodeInfo);
   const isSmallRange = timePreset === 'last15m' || timePreset === 'last1h';
-  const refreshInterval = isActive && hasQueryApiKey && isSmallRange ? AUTO_REFRESH_MS : false;
+  const refreshInterval =
+    isActive &&
+    hasQueryApiKey &&
+    isSmallRange &&
+    recoverySelectionIds.length === 0 &&
+    !recoveryModalOpen
+      ? AUTO_REFRESH_MS
+      : false;
   const refreshEnabled = typeof refreshInterval === 'number';
 
   const range = useMemo(() => {
@@ -1092,6 +1186,15 @@ export default function EventsExplorerPanel({
     () => fetchedEvents.filter((item) => matchesQuickFilters(item, quickFilters)),
     [fetchedEvents, quickFilters]
   );
+  const recoverySelectionSet = useMemo(
+    () => new Set(recoverySelectionIds),
+    [recoverySelectionIds]
+  );
+  const selectedRecoveryEvents = useMemo(
+    () => events.filter((item) => recoverySelectionSet.has(item.id)),
+    [events, recoverySelectionSet]
+  );
+  const selectedRecoveryCount = selectedRecoveryEvents.length;
 
   const portnumOptions = useMemo(() => {
     const values = new Set<string>();
@@ -1272,6 +1375,45 @@ export default function EventsExplorerPanel({
     setCopyEventIdState('idle');
   }, [selectedEventId]);
 
+  useEffect(() => {
+    const visibleIds = new Set(events.map((event) => event.id));
+    setRecoverySelectionIds((current) => {
+      const filtered = current.filter((id) => visibleIds.has(id));
+      return areSameStringArray(current, filtered) ? current : filtered;
+    });
+    setRecoveryAnchorEventId((current) => (current && visibleIds.has(current) ? current : null));
+  }, [events]);
+
+  useEffect(() => {
+    if (!recoveryModalOpen) {
+      return;
+    }
+    if (recoverySelectionIds.length > 0) {
+      return;
+    }
+    setRecoveryModalOpen(false);
+    setRecoveryPreview(null);
+    setRecoveryPreviewError(null);
+    setRecoveryCreateError(null);
+  }, [recoveryModalOpen, recoverySelectionIds]);
+
+  useEffect(() => {
+    if (!recoveryModalOpen || recoverySelectionIds.length === 0) {
+      return;
+    }
+    void fetchRecoveryPreview(recoverySelectionIds, { preserveEditedName: true });
+  }, [recoveryModalOpen, recoverySelectionIds.join(',')]);
+
+  useEffect(() => {
+    if (!recoveryToast) {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      setRecoveryToast(null);
+    }, 3200);
+    return () => window.clearTimeout(handle);
+  }, [recoveryToast]);
+
   const handlePrefetchDetail = (eventId: string) => {
     if (!hasQueryApiKey) {
       return;
@@ -1281,6 +1423,122 @@ export default function EventsExplorerPanel({
       queryFn: ({ signal }) => getUnifiedEventById(eventId, { signal }),
       staleTime: 30_000
     });
+  };
+
+  const fetchRecoveryPreview = async (
+    eventIds: string[],
+    options?: { preserveEditedName?: boolean }
+  ) => {
+    if (eventIds.length === 0) {
+      return;
+    }
+    setRecoveryPreviewLoading(true);
+    setRecoveryPreviewError(null);
+    try {
+      const preview = await previewSessionRecoveryFromEvents({ eventIds });
+      setRecoveryPreview(preview);
+      if (!options?.preserveEditedName || !recoverySessionNameEdited) {
+        setRecoverySessionName(preview.defaultSessionName ?? '');
+      }
+    } catch (error) {
+      const requestId = buildRequestId(error);
+      const baseMessage =
+        error instanceof ApiError ? error.message : 'Failed to validate selected events';
+      setRecoveryPreviewError(requestId ? `${baseMessage} (X-Request-Id: ${requestId})` : baseMessage);
+      setRecoveryPreview(null);
+    } finally {
+      setRecoveryPreviewLoading(false);
+    }
+  };
+
+  const computeContiguousSelection = (anchorEventId: string, targetEventId: string): string[] => {
+    const anchorIndex = events.findIndex((event) => event.id === anchorEventId);
+    const targetIndex = events.findIndex((event) => event.id === targetEventId);
+    if (anchorIndex < 0 || targetIndex < 0) {
+      return [targetEventId];
+    }
+    const start = Math.min(anchorIndex, targetIndex);
+    const end = Math.max(anchorIndex, targetIndex);
+    return events.slice(start, end + 1).map((event) => event.id);
+  };
+
+  const handleToggleRecoverySelection = (
+    eventItem: UnifiedEventListItem,
+    options?: { shiftKey?: boolean }
+  ) => {
+    const shiftKey = Boolean(options?.shiftKey);
+    if (shiftKey && recoveryAnchorEventId) {
+      setRecoverySelectionIds(computeContiguousSelection(recoveryAnchorEventId, eventItem.id));
+      return;
+    }
+
+    if (recoverySelectionIds.length === 1 && recoverySelectionIds[0] === eventItem.id) {
+      setRecoverySelectionIds([]);
+      setRecoveryAnchorEventId(null);
+      return;
+    }
+
+    setRecoverySelectionIds([eventItem.id]);
+    setRecoveryAnchorEventId(eventItem.id);
+  };
+
+  const handleOpenRecoveryModal = () => {
+    if (recoverySelectionIds.length === 0) {
+      return;
+    }
+    setRecoveryModalOpen(true);
+    setRecoveryPreview(null);
+    setRecoveryPreviewError(null);
+    setRecoveryCreateError(null);
+    setRecoverySessionName('');
+    setRecoverySessionNameEdited(false);
+    setRecoveryNotes('');
+    void fetchRecoveryPreview(recoverySelectionIds, { preserveEditedName: false });
+  };
+
+  const handleCloseRecoveryModal = () => {
+    if (recoveryCreatePending) {
+      return;
+    }
+    setRecoveryModalOpen(false);
+    setRecoveryPreviewError(null);
+    setRecoveryCreateError(null);
+  };
+
+  const handleCreateRecoveredSession = async () => {
+    if (!recoveryPreview || !recoveryPreview.canCreate || recoverySelectionIds.length === 0) {
+      return;
+    }
+    setRecoveryCreatePending(true);
+    setRecoveryCreateError(null);
+    try {
+      const result = await createSessionFromEventSelection({
+        eventIds: recoverySelectionIds,
+        name: recoverySessionName.trim() || undefined,
+        notes: recoveryNotes.trim() || undefined
+      });
+      setRecoveryModalOpen(false);
+      setRecoverySelectionIds([]);
+      setRecoveryAnchorEventId(null);
+      setRecoveryPreview(null);
+      setRecoveryPreviewError(null);
+      setRecoveryNotes('');
+      setRecoverySessionNameEdited(false);
+      setRecoveryToast(
+        `Recovered session created (${result.attachedEventCount} events attached).`
+      );
+      void queryClient.invalidateQueries({ queryKey: ['sessions', result.deviceId] });
+      void queryClient.invalidateQueries({ queryKey: ['session', result.sessionId] });
+      void queryClient.invalidateQueries({ queryKey: ['sessionStats', result.sessionId] });
+      onOpenRecoveredSession?.(result);
+    } catch (error) {
+      const requestId = buildRequestId(error);
+      const baseMessage =
+        error instanceof ApiError ? error.message : 'Failed to create recovered session';
+      setRecoveryCreateError(requestId ? `${baseMessage} (X-Request-Id: ${requestId})` : baseMessage);
+    } finally {
+      setRecoveryCreatePending(false);
+    }
   };
 
   const handleDeviceInputChange = (value: string) => {
@@ -1367,7 +1625,13 @@ export default function EventsExplorerPanel({
     writeSavedEventsViews(nextViews);
   };
 
-  const handleSelectEvent = (eventItem: UnifiedEventListItem) => {
+  const handleSelectEvent = (
+    eventItem: UnifiedEventListItem,
+    options?: { shiftKey?: boolean }
+  ) => {
+    if (options?.shiftKey) {
+      handleToggleRecoverySelection(eventItem, { shiftKey: true });
+    }
     setSelectedEventId(eventItem.id);
     const rowDeviceUid = normalizeInputText(eventItem.deviceUid);
     if (rowDeviceUid) {
@@ -1433,10 +1697,19 @@ export default function EventsExplorerPanel({
     () => ({
       events,
       selectedEventId,
+      selectedRecoveryEventIds: recoverySelectionSet,
       onSelectEvent: handleSelectEvent,
+      onToggleRecoverySelection: handleToggleRecoverySelection,
       onPrefetchDetail: handlePrefetchDetail
     }),
-    [events, selectedEventId, handleSelectEvent, handlePrefetchDetail]
+    [
+      events,
+      selectedEventId,
+      recoverySelectionSet,
+      handleSelectEvent,
+      handleToggleRecoverySelection,
+      handlePrefetchDetail
+    ]
   );
 
   return (
@@ -1444,6 +1717,11 @@ export default function EventsExplorerPanel({
       <div className="events-explorer__header">
         <h3>Events</h3>
       </div>
+      {recoveryToast ? (
+        <div className="events-explorer__recovery-toast" role="status" aria-live="polite">
+          {recoveryToast}
+        </div>
+      ) : null}
 
       {!hasQueryApiKey ? (
         <div className="events-explorer__message">Events requires QUERY key.</div>
@@ -1639,6 +1917,34 @@ export default function EventsExplorerPanel({
             </div>
           ) : null}
 
+          <div className="events-explorer__recovery-bar">
+            <div className="events-explorer__recovery-meta">
+              Recovery selection: <strong>{selectedRecoveryCount}</strong> row
+              {selectedRecoveryCount === 1 ? '' : 's'}
+            </div>
+            <div className="events-explorer__recovery-actions">
+              <button
+                type="button"
+                className="controls__button controls__button--compact events-explorer__recover-button"
+                onClick={handleOpenRecoveryModal}
+                disabled={selectedRecoveryCount === 0}
+              >
+                Create session from selection
+              </button>
+              <button
+                type="button"
+                className="controls__button controls__button--compact"
+                onClick={() => {
+                  setRecoverySelectionIds([]);
+                  setRecoveryAnchorEventId(null);
+                }}
+                disabled={selectedRecoveryCount === 0}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+
           <div className="events-explorer__table-wrap">
             <div className="events-explorer__table" role="table" aria-label="Events">
               <div className="events-explorer__virtual-row events-explorer__virtual-row--header" role="row">
@@ -1695,6 +2001,132 @@ export default function EventsExplorerPanel({
           <option key={portnum} value={portnum} />
         ))}
       </datalist>
+
+      {recoveryModalOpen ? (
+        <div
+          className="events-explorer__modal-backdrop"
+          role="presentation"
+          onClick={handleCloseRecoveryModal}
+        >
+          <div
+            className="events-explorer__modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Create session from selected events"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h4>Create Session from Selection</h4>
+            <div className="events-explorer__modal-summary">
+              <div>
+                <span>Selected</span>
+                <strong>{recoveryPreview?.selectedEventCount ?? selectedRecoveryCount}</strong>
+              </div>
+              <div>
+                <span>Eligible</span>
+                <strong>{recoveryPreview?.eligibleEventCount ?? '—'}</strong>
+              </div>
+              <div>
+                <span>Start</span>
+                <strong>{formatTimestamp(recoveryPreview?.startTime)}</strong>
+              </div>
+              <div>
+                <span>End</span>
+                <strong>{formatTimestamp(recoveryPreview?.endTime)}</strong>
+              </div>
+              <div>
+                <span>Duration</span>
+                <strong>{formatDurationLabel(recoveryPreview?.durationMs)}</strong>
+              </div>
+              <div>
+                <span>Device</span>
+                <strong>
+                  {recoveryPreview?.inferredDeviceUid
+                    ? recoveryPreview.inferredDeviceName
+                      ? `${recoveryPreview.inferredDeviceName} (${recoveryPreview.inferredDeviceUid})`
+                      : recoveryPreview.inferredDeviceUid
+                    : '—'}
+                </strong>
+              </div>
+              <div>
+                <span>Warnings</span>
+                <strong>{recoveryPreview?.warningCount ?? 0}</strong>
+              </div>
+            </div>
+
+            <label className="events-explorer__modal-field">
+              Session name
+              <input
+                value={recoverySessionName}
+                onChange={(event) => {
+                  setRecoverySessionName(event.target.value);
+                  setRecoverySessionNameEdited(true);
+                }}
+                placeholder="Recovered session"
+              />
+            </label>
+
+            <label className="events-explorer__modal-field">
+              Notes (optional)
+              <textarea
+                value={recoveryNotes}
+                onChange={(event) => setRecoveryNotes(event.target.value)}
+                rows={3}
+                placeholder="Recovery notes"
+              />
+            </label>
+
+            {recoveryPreviewLoading ? (
+              <div className="events-explorer__message">Validating selection…</div>
+            ) : null}
+            {recoveryPreviewError ? (
+              <div className="events-explorer__error">{recoveryPreviewError}</div>
+            ) : null}
+            {recoveryCreateError ? (
+              <div className="events-explorer__error">{recoveryCreateError}</div>
+            ) : null}
+
+            {recoveryPreview?.warnings?.length ? (
+              <ul className="events-explorer__modal-list">
+                {recoveryPreview.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            ) : null}
+
+            {recoveryPreview?.blockingErrors?.length ? (
+              <ul className="events-explorer__modal-list events-explorer__modal-list--blocking">
+                {recoveryPreview.blockingErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            ) : null}
+
+            <div className="events-explorer__modal-actions">
+              <button
+                type="button"
+                className="events-explorer__modal-cancel"
+                onClick={handleCloseRecoveryModal}
+                disabled={recoveryCreatePending}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="events-explorer__modal-confirm"
+                onClick={() => void handleCreateRecoveredSession()}
+                disabled={
+                  recoveryCreatePending ||
+                  recoveryPreviewLoading ||
+                  !recoveryPreview ||
+                  !recoveryPreview.canCreate
+                }
+              >
+                {recoveryCreatePending ? 'Creating…' : 'Create recovered session'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {selectedEventId ? (
         <aside className="events-explorer__drawer" aria-label="Event detail">

--- a/src/modules/events/dto/recover-session.dto.ts
+++ b/src/modules/events/dto/recover-session.dto.ts
@@ -1,0 +1,28 @@
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID
+} from 'class-validator';
+
+export class RecoverSessionPreviewDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(500)
+  @IsUUID('all', { each: true })
+  eventIds!: string[];
+}
+
+export class RecoverSessionCreateDto extends RecoverSessionPreviewDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -1,7 +1,20 @@
-import { BadRequestException, Controller, Get, NotFoundException, Param, Query, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards
+} from '@nestjs/common';
 import { ApiKeyScope } from '@prisma/client';
 import { RequireApiKeyScope } from '../../common/decorators/api-key-scopes.decorator';
 import { ApiKeyGuard } from '../../common/guards/api-key.guard';
+import { getOwnerIdFromRequest, type OwnerContextRequest } from '../../common/owner-context';
+import { RecoverSessionCreateDto, RecoverSessionPreviewDto } from './dto/recover-session.dto';
 import { decodeCursor, EventDetail, EventsListResponse, EventsService, EventsSource } from './events.service';
 
 @UseGuards(ApiKeyGuard)
@@ -53,6 +66,32 @@ export class EventsController {
       throw new NotFoundException('Event not found');
     }
     return event;
+  }
+
+  @Post('recover-session/preview')
+  async previewRecoverSession(
+    @Body() body: RecoverSessionPreviewDto,
+    @Req() request: OwnerContextRequest
+  ) {
+    const ownerId = getOwnerIdFromRequest(request);
+    return this.eventsService.previewRecoverSessionFromEvents({
+      eventIds: body.eventIds,
+      ownerId
+    });
+  }
+
+  @Post('recover-session')
+  async createRecoveredSession(
+    @Body() body: RecoverSessionCreateDto,
+    @Req() request: OwnerContextRequest
+  ) {
+    const ownerId = getOwnerIdFromRequest(request);
+    return this.eventsService.createSessionFromSelectedEvents({
+      eventIds: body.eventIds,
+      ownerId,
+      name: body.name,
+      notes: body.notes
+    });
   }
 }
 

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Prisma, WebhookEventSource } from '@prisma/client';
+import { BIN_SIZE_DEG } from '../coverage/coverage.constants';
 
 export type EventsSource = 'meshtastic' | 'lorawan' | 'agent' | 'sim';
 
@@ -60,6 +61,52 @@ export type EventsListResponse = {
   returnedCount: number;
   totalFilteredCount?: number;
 };
+
+export type RecoverSessionPreview = {
+  selectedEventCount: number;
+  eligibleEventCount: number;
+  eligibleMeasurementCount: number;
+  alreadyAssignedEventCount: number;
+  incompatibleEventCount: number;
+  warningCount: number;
+  warnings: string[];
+  blockingErrors: string[];
+  canCreate: boolean;
+  startTime: string | null;
+  endTime: string | null;
+  durationMs: number | null;
+  inferredDeviceId: string | null;
+  inferredDeviceUid: string | null;
+  inferredDeviceName: string | null;
+  mixedRawDevices: boolean;
+  mixedMeasurementDevices: boolean;
+  hasLargeTimeGap: boolean;
+  maxGapMs: number | null;
+  defaultSessionName: string | null;
+};
+
+export type RecoverSessionResult = {
+  sessionId: string;
+  deviceId: string;
+  deviceUid: string | null;
+  sessionName: string | null;
+  selectedEventCount: number;
+  attachedEventCount: number;
+  attachedMeasurementCount: number;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+};
+
+type RecoverSessionSummaryInternal = RecoverSessionPreview & {
+  startAt: Date | null;
+  endAt: Date | null;
+  eligibleMeasurementIds: string[];
+  affectedDays: Date[];
+};
+
+const LARGE_SELECTION_GAP_MS = 20 * 60 * 1000;
+const MAX_RECOVERY_EVENT_IDS = 500;
 
 @Injectable()
 export class EventsService {
@@ -246,6 +293,655 @@ export class EventsService {
       payloadJson: row.payloadJson
     };
   }
+
+  async previewRecoverSessionFromEvents(params: {
+    eventIds: string[];
+    ownerId?: string;
+  }): Promise<RecoverSessionPreview> {
+    return this.prisma.$transaction(async (tx) => {
+      const summary = await this.buildRecoverSessionSummary(tx, params);
+      return toRecoverSessionPreview(summary);
+    });
+  }
+
+  async createSessionFromSelectedEvents(params: {
+    eventIds: string[];
+    ownerId?: string;
+    name?: string;
+    notes?: string;
+  }): Promise<RecoverSessionResult> {
+    return this.prisma.$transaction(async (tx) => {
+      const summary = await this.buildRecoverSessionSummary(tx, params);
+
+      if (!summary.canCreate) {
+        throw new BadRequestException(summary.blockingErrors.join(' '));
+      }
+      if (!summary.startAt || !summary.endAt || !summary.inferredDeviceId) {
+        throw new BadRequestException('Could not infer a valid session window and device');
+      }
+
+      const createdSession = await tx.session.create({
+        data: {
+          deviceId: summary.inferredDeviceId,
+          name: normalizeOptionalText(params.name) ?? summary.defaultSessionName ?? undefined,
+          notes: normalizeOptionalText(params.notes),
+          startedAt: summary.startAt,
+          endedAt: summary.endAt
+        },
+        select: {
+          id: true,
+          deviceId: true,
+          name: true
+        }
+      });
+
+      const updated = await tx.measurement.updateMany({
+        where: {
+          id: { in: summary.eligibleMeasurementIds },
+          sessionId: null
+        },
+        data: {
+          sessionId: createdSession.id
+        }
+      });
+
+      if (updated.count !== summary.eligibleMeasurementIds.length) {
+        throw new BadRequestException(
+          'Selected events changed while recovering. Refresh the selection and try again.'
+        );
+      }
+
+      await this.rebuildCoverageBinsForRecoveredSession(tx, {
+        deviceId: createdSession.deviceId,
+        newSessionId: createdSession.id,
+        affectedDays: summary.affectedDays
+      });
+
+      const attachedEventCount = summary.eligibleEventCount;
+      const attachedMeasurementCount = summary.eligibleMeasurementCount;
+      const durationMs = Math.max(0, summary.endAt.getTime() - summary.startAt.getTime());
+
+      return {
+        sessionId: createdSession.id,
+        deviceId: createdSession.deviceId,
+        deviceUid: summary.inferredDeviceUid,
+        sessionName: createdSession.name ?? null,
+        selectedEventCount: summary.selectedEventCount,
+        attachedEventCount,
+        attachedMeasurementCount,
+        startTime: summary.startAt.toISOString(),
+        endTime: summary.endAt.toISOString(),
+        durationMs
+      };
+    });
+  }
+
+  private async buildRecoverSessionSummary(
+    tx: Prisma.TransactionClient,
+    params: { eventIds: string[]; ownerId?: string }
+  ): Promise<RecoverSessionSummaryInternal> {
+    const eventIds = normalizeEventIdSelection(params.eventIds);
+
+    const events = await tx.webhookEvent.findMany({
+      where: {
+        id: { in: eventIds }
+      },
+      select: {
+        id: true,
+        receivedAt: true,
+        deviceUid: true
+      }
+    });
+
+    if (events.length !== eventIds.length) {
+      const foundIds = new Set(events.map((event) => event.id));
+      const missing = eventIds.filter((id) => !foundIds.has(id));
+      throw new BadRequestException(
+        `Some selected events were not found: ${missing.slice(0, 5).join(', ')}`
+      );
+    }
+
+    const eventById = new Map(events.map((event) => [event.id, event]));
+    const orderedEvents = eventIds.map((id) => eventById.get(id)).filter(Boolean) as Array<{
+      id: string;
+      receivedAt: Date;
+      deviceUid: string | null;
+    }>;
+
+    const measurements = await tx.measurement.findMany({
+      where: {
+        sourceEventId: {
+          in: eventIds
+        }
+      },
+      select: {
+        id: true,
+        sourceEventId: true,
+        sessionId: true,
+        deviceId: true,
+        capturedAt: true,
+        lat: true,
+        lon: true,
+        gatewayId: true,
+        rssi: true,
+        snr: true,
+        device: {
+          select: {
+            id: true,
+            deviceUid: true,
+            name: true,
+            ownerId: true
+          }
+        }
+      }
+    });
+
+    const measurementsByEventId = new Map<string, typeof measurements>();
+    for (const measurement of measurements) {
+      const sourceEventId = measurement.sourceEventId;
+      if (!sourceEventId) {
+        continue;
+      }
+      const current = measurementsByEventId.get(sourceEventId);
+      if (current) {
+        current.push(measurement);
+      } else {
+        measurementsByEventId.set(sourceEventId, [measurement]);
+      }
+    }
+
+    await this.assertRecoverSelectionOwnerScope(tx, {
+      ownerId: params.ownerId,
+      selectedEvents: orderedEvents,
+      measurementsByEventId
+    });
+
+    let earliest: Date | null = null;
+    let latest: Date | null = null;
+    for (const event of orderedEvents) {
+      if (!earliest || event.receivedAt < earliest) {
+        earliest = event.receivedAt;
+      }
+      if (!latest || event.receivedAt > latest) {
+        latest = event.receivedAt;
+      }
+    }
+
+    const alreadyAssignedEventIds = new Set<string>();
+    const incompatibleEventIds = new Set<string>();
+    const eligibleMeasurements: typeof measurements = [];
+    const eligibleEventIds = new Set<string>();
+
+    for (const event of orderedEvents) {
+      const eventMeasurements = measurementsByEventId.get(event.id) ?? [];
+      if (eventMeasurements.length === 0) {
+        incompatibleEventIds.add(event.id);
+        continue;
+      }
+
+      let hasAssigned = false;
+      for (const measurement of eventMeasurements) {
+        if (measurement.sessionId) {
+          hasAssigned = true;
+        } else {
+          eligibleMeasurements.push(measurement);
+          eligibleEventIds.add(event.id);
+        }
+      }
+      if (hasAssigned) {
+        alreadyAssignedEventIds.add(event.id);
+      }
+    }
+
+    const eligibleMeasurementIds = eligibleMeasurements.map((measurement) => measurement.id);
+
+    const eligibleDeviceIds = new Set(eligibleMeasurements.map((measurement) => measurement.deviceId));
+    const mixedMeasurementDevices = eligibleDeviceIds.size > 1;
+    const inferredDevice =
+      eligibleMeasurements.length > 0 && eligibleDeviceIds.size === 1
+        ? eligibleMeasurements[0].device
+        : null;
+
+    const rawDeviceUids = new Set(
+      orderedEvents
+        .map((event) => normalizeOptionalText(event.deviceUid))
+        .filter((value): value is string => Boolean(value))
+    );
+    const mixedRawDevices = rawDeviceUids.size > 1;
+
+    const maxGapMs = computeMaxGapMs(orderedEvents);
+    const hasLargeTimeGap = maxGapMs !== null && maxGapMs >= LARGE_SELECTION_GAP_MS;
+
+    const warnings: string[] = [];
+    if (alreadyAssignedEventIds.size > 0) {
+      warnings.push(
+        `${alreadyAssignedEventIds.size} selected event${alreadyAssignedEventIds.size === 1 ? '' : 's'} already assigned to another session`
+      );
+    }
+    if (incompatibleEventIds.size > 0) {
+      warnings.push(
+        `${incompatibleEventIds.size} selected event${incompatibleEventIds.size === 1 ? '' : 's'} have no usable location measurement`
+      );
+    }
+    if (mixedRawDevices) {
+      warnings.push('Selection includes multiple raw device identifiers');
+    }
+    if (hasLargeTimeGap && maxGapMs !== null) {
+      warnings.push(`Selection includes a large internal time gap (${formatDuration(maxGapMs)})`);
+    }
+
+    const blockingErrors: string[] = [];
+    if (alreadyAssignedEventIds.size > 0) {
+      blockingErrors.push(
+        'Some selected events are already assigned to another session. Adjust selection and retry.'
+      );
+    }
+    if (eligibleMeasurements.length === 0) {
+      blockingErrors.push('No usable route/location events found in this selection.');
+    }
+    if (mixedMeasurementDevices) {
+      blockingErrors.push('Selected events resolve to multiple devices. Use a single-device range.');
+    }
+
+    const durationMs =
+      earliest && latest ? Math.max(0, latest.getTime() - earliest.getTime()) : null;
+    const affectedDays = Array.from(
+      new Set(
+        eligibleMeasurements
+          .map((measurement) => startOfUtcDay(measurement.capturedAt).toISOString())
+      )
+    ).map((isoValue) => new Date(isoValue));
+
+    const preview: RecoverSessionSummaryInternal = {
+      selectedEventCount: orderedEvents.length,
+      eligibleEventCount: eligibleEventIds.size,
+      eligibleMeasurementCount: eligibleMeasurements.length,
+      alreadyAssignedEventCount: alreadyAssignedEventIds.size,
+      incompatibleEventCount: incompatibleEventIds.size,
+      warningCount: warnings.length,
+      warnings,
+      blockingErrors,
+      canCreate: blockingErrors.length === 0,
+      startTime: earliest ? earliest.toISOString() : null,
+      endTime: latest ? latest.toISOString() : null,
+      durationMs,
+      inferredDeviceId: inferredDevice?.id ?? null,
+      inferredDeviceUid: inferredDevice?.deviceUid ?? null,
+      inferredDeviceName: inferredDevice?.name ?? null,
+      mixedRawDevices,
+      mixedMeasurementDevices,
+      hasLargeTimeGap,
+      maxGapMs,
+      defaultSessionName:
+        earliest && latest ? buildRecoverDefaultSessionName(earliest, latest) : null,
+      startAt: earliest,
+      endAt: latest,
+      eligibleMeasurementIds,
+      affectedDays
+    };
+
+    return preview;
+  }
+
+  private async assertRecoverSelectionOwnerScope(
+    tx: Prisma.TransactionClient,
+    params: {
+      ownerId?: string;
+      selectedEvents: Array<{
+        id: string;
+        receivedAt: Date;
+        deviceUid: string | null;
+      }>;
+      measurementsByEventId: Map<
+        string,
+        Array<{
+          id: string;
+          sourceEventId: string | null;
+          sessionId: string | null;
+          deviceId: string;
+          capturedAt: Date;
+          lat: number;
+          lon: number;
+          gatewayId: string | null;
+          rssi: number | null;
+          snr: number | null;
+          device: {
+            id: string;
+            deviceUid: string;
+            name: string | null;
+            ownerId: string | null;
+          };
+        }>
+      >;
+    }
+  ): Promise<void> {
+    if (!params.ownerId) {
+      return;
+    }
+
+    const eventDeviceUids = Array.from(
+      new Set(
+        params.selectedEvents
+          .map((event) => normalizeOptionalText(event.deviceUid))
+          .filter((value): value is string => Boolean(value))
+      )
+    );
+
+    const devices = eventDeviceUids.length
+      ? await tx.device.findMany({
+          where: {
+            deviceUid: { in: eventDeviceUids }
+          },
+          select: {
+            deviceUid: true,
+            ownerId: true
+          }
+        })
+      : [];
+    const ownerByDeviceUid = new Map(devices.map((device) => [device.deviceUid, device.ownerId]));
+
+    for (const event of params.selectedEvents) {
+      const ownerCandidates = new Set<string | null>();
+      const measurements = params.measurementsByEventId.get(event.id) ?? [];
+      for (const measurement of measurements) {
+        ownerCandidates.add(measurement.device.ownerId ?? null);
+      }
+
+      const eventDeviceUid = normalizeOptionalText(event.deviceUid);
+      if (eventDeviceUid) {
+        ownerCandidates.add(ownerByDeviceUid.get(eventDeviceUid) ?? null);
+      }
+
+      if (ownerCandidates.size === 0) {
+        throw new BadRequestException(
+          `Could not verify ownership for selected event ${event.id}`
+        );
+      }
+      if (
+        Array.from(ownerCandidates).some(
+          (ownerCandidate) => ownerCandidate !== params.ownerId
+        )
+      ) {
+        throw new BadRequestException(
+          'Selected events include data outside the current owner scope'
+        );
+      }
+    }
+  }
+
+  private async rebuildCoverageBinsForRecoveredSession(
+    tx: Prisma.TransactionClient,
+    params: {
+      deviceId: string;
+      newSessionId: string;
+      affectedDays: Date[];
+    }
+  ): Promise<void> {
+    if (params.affectedDays.length === 0) {
+      return;
+    }
+
+    for (const day of params.affectedDays) {
+      const dayStart = startOfUtcDay(day);
+      const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
+
+      await tx.coverageBin.deleteMany({
+        where: {
+          deviceId: params.deviceId,
+          day: dayStart,
+          OR: [{ sessionId: null }, { sessionId: params.newSessionId }]
+        }
+      });
+
+      const measurements = await tx.measurement.findMany({
+        where: {
+          deviceId: params.deviceId,
+          capturedAt: { gte: dayStart, lt: dayEnd },
+          OR: [{ sessionId: null }, { sessionId: params.newSessionId }]
+        },
+        select: {
+          sessionId: true,
+          gatewayId: true,
+          lat: true,
+          lon: true,
+          rssi: true,
+          snr: true
+        }
+      });
+
+      if (measurements.length === 0) {
+        continue;
+      }
+
+      const aggregates = new Map<
+        string,
+        {
+          sessionId: string | null;
+          gatewayId: string | null;
+          latBin: number;
+          lonBin: number;
+          count: number;
+          rssiSum: number;
+          rssiCount: number;
+          rssiMin: number | null;
+          rssiMax: number | null;
+          snrSum: number;
+          snrCount: number;
+          snrMin: number | null;
+          snrMax: number | null;
+        }
+      >();
+
+      for (const measurement of measurements) {
+        const latBin = Math.floor(measurement.lat / BIN_SIZE_DEG);
+        const lonBin = Math.floor(measurement.lon / BIN_SIZE_DEG);
+        const key = [
+          measurement.sessionId ?? 'null',
+          measurement.gatewayId ?? 'null',
+          latBin,
+          lonBin
+        ].join('|');
+        const existing = aggregates.get(key);
+        const aggregate =
+          existing ??
+          {
+            sessionId: measurement.sessionId,
+            gatewayId: measurement.gatewayId,
+            latBin,
+            lonBin,
+            count: 0,
+            rssiSum: 0,
+            rssiCount: 0,
+            rssiMin: null,
+            rssiMax: null,
+            snrSum: 0,
+            snrCount: 0,
+            snrMin: null,
+            snrMax: null
+          };
+
+        aggregate.count += 1;
+        if (typeof measurement.rssi === 'number' && Number.isFinite(measurement.rssi)) {
+          aggregate.rssiSum += measurement.rssi;
+          aggregate.rssiCount += 1;
+          aggregate.rssiMin =
+            aggregate.rssiMin === null
+              ? measurement.rssi
+              : Math.min(aggregate.rssiMin, measurement.rssi);
+          aggregate.rssiMax =
+            aggregate.rssiMax === null
+              ? measurement.rssi
+              : Math.max(aggregate.rssiMax, measurement.rssi);
+        }
+        if (typeof measurement.snr === 'number' && Number.isFinite(measurement.snr)) {
+          aggregate.snrSum += measurement.snr;
+          aggregate.snrCount += 1;
+          aggregate.snrMin =
+            aggregate.snrMin === null
+              ? measurement.snr
+              : Math.min(aggregate.snrMin, measurement.snr);
+          aggregate.snrMax =
+            aggregate.snrMax === null
+              ? measurement.snr
+              : Math.max(aggregate.snrMax, measurement.snr);
+        }
+
+        if (!existing) {
+          aggregates.set(key, aggregate);
+        }
+      }
+
+      const rows = Array.from(aggregates.values()).map((aggregate) => ({
+        deviceId: params.deviceId,
+        sessionId: aggregate.sessionId,
+        gatewayId: aggregate.gatewayId,
+        day: dayStart,
+        latBin: aggregate.latBin,
+        lonBin: aggregate.lonBin,
+        count: aggregate.count,
+        rssiAvg:
+          aggregate.rssiCount > 0 ? aggregate.rssiSum / aggregate.rssiCount : null,
+        snrAvg:
+          aggregate.snrCount > 0 ? aggregate.snrSum / aggregate.snrCount : null,
+        rssiMin: aggregate.rssiMin,
+        rssiMax: aggregate.rssiMax,
+        snrMin: aggregate.snrMin,
+        snrMax: aggregate.snrMax
+      }));
+
+      await tx.coverageBin.createMany({
+        data: rows
+      });
+    }
+  }
+}
+
+function toRecoverSessionPreview(
+  summary: RecoverSessionSummaryInternal
+): RecoverSessionPreview {
+  return {
+    selectedEventCount: summary.selectedEventCount,
+    eligibleEventCount: summary.eligibleEventCount,
+    eligibleMeasurementCount: summary.eligibleMeasurementCount,
+    alreadyAssignedEventCount: summary.alreadyAssignedEventCount,
+    incompatibleEventCount: summary.incompatibleEventCount,
+    warningCount: summary.warningCount,
+    warnings: summary.warnings,
+    blockingErrors: summary.blockingErrors,
+    canCreate: summary.canCreate,
+    startTime: summary.startTime,
+    endTime: summary.endTime,
+    durationMs: summary.durationMs,
+    inferredDeviceId: summary.inferredDeviceId,
+    inferredDeviceUid: summary.inferredDeviceUid,
+    inferredDeviceName: summary.inferredDeviceName,
+    mixedRawDevices: summary.mixedRawDevices,
+    mixedMeasurementDevices: summary.mixedMeasurementDevices,
+    hasLargeTimeGap: summary.hasLargeTimeGap,
+    maxGapMs: summary.maxGapMs,
+    defaultSessionName: summary.defaultSessionName
+  };
+}
+
+function normalizeEventIdSelection(eventIds: string[]): string[] {
+  if (!Array.isArray(eventIds) || eventIds.length === 0) {
+    throw new BadRequestException('eventIds must include at least one event id');
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const rawEventId of eventIds) {
+    if (typeof rawEventId !== 'string') {
+      continue;
+    }
+    const trimmed = rawEventId.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  if (normalized.length === 0) {
+    throw new BadRequestException('eventIds must include at least one valid event id');
+  }
+  if (normalized.length > MAX_RECOVERY_EVENT_IDS) {
+    throw new BadRequestException(
+      `eventIds cannot exceed ${MAX_RECOVERY_EVENT_IDS} entries`
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function computeMaxGapMs(
+  events: Array<{
+    id: string;
+    receivedAt: Date;
+    deviceUid: string | null;
+  }>
+): number | null {
+  if (events.length < 2) {
+    return null;
+  }
+  const ordered = [...events].sort((left, right) => {
+    const leftMs = left.receivedAt.getTime();
+    const rightMs = right.receivedAt.getTime();
+    if (leftMs === rightMs) {
+      return left.id.localeCompare(right.id);
+    }
+    return leftMs - rightMs;
+  });
+
+  let maxGap = 0;
+  for (let index = 1; index < ordered.length; index += 1) {
+    const gap = ordered[index].receivedAt.getTime() - ordered[index - 1].receivedAt.getTime();
+    if (gap > maxGap) {
+      maxGap = gap;
+    }
+  }
+
+  return maxGap > 0 ? maxGap : null;
+}
+
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function buildRecoverDefaultSessionName(startAt: Date, endAt: Date): string {
+  const startIso = startAt.toISOString();
+  const endIso = endAt.toISOString();
+  const startDay = startIso.slice(0, 10);
+  const startClock = startIso.slice(11, 16);
+  const endDay = endIso.slice(0, 10);
+  const endClock = endIso.slice(11, 16);
+
+  if (startDay === endDay) {
+    return `Recovered ${startDay} ${startClock}-${endClock} UTC`;
+  }
+  return `Recovered ${startDay} ${startClock} to ${endDay} ${endClock} UTC`;
+}
+
+function startOfUtcDay(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
 }
 
 function buildWhereClause(params: ListEventsParams): Prisma.WebhookEventWhereInput | undefined {

--- a/test/events.e2e-spec.ts
+++ b/test/events.e2e-spec.ts
@@ -15,6 +15,9 @@ describe('Events API e2e', () => {
   let queryKeyId: string | null = null;
   let ingestKeyId: string | null = null;
   let createdEventIds: string[] = [];
+  let createdMeasurementIds: string[] = [];
+  let createdSessionIds: string[] = [];
+  let createdDeviceIds: string[] = [];
 
   beforeAll(async () => {
     process.env.LORAWAN_WORKER_ENABLED = 'false';
@@ -51,18 +54,90 @@ describe('Events API e2e', () => {
   });
 
   afterEach(async () => {
-    if (createdEventIds.length === 0) {
-      return;
+    if (createdDeviceIds.length > 0) {
+      await prisma.coverageBin.deleteMany({
+        where: {
+          deviceId: { in: createdDeviceIds }
+        }
+      });
     }
-    await prisma.webhookEvent.deleteMany({
-      where: {
-        id: { in: createdEventIds }
-      }
-    });
+    if (createdSessionIds.length > 0) {
+      await prisma.coverageBin.deleteMany({
+        where: {
+          sessionId: { in: createdSessionIds }
+        }
+      });
+    }
+    if (createdMeasurementIds.length > 0) {
+      await prisma.measurement.deleteMany({
+        where: {
+          id: { in: createdMeasurementIds }
+        }
+      });
+    }
+    if (createdSessionIds.length > 0) {
+      await prisma.session.deleteMany({
+        where: {
+          id: { in: createdSessionIds }
+        }
+      });
+    }
+    if (createdDeviceIds.length > 0) {
+      await prisma.device.deleteMany({
+        where: {
+          id: { in: createdDeviceIds }
+        }
+      });
+    }
+    if (createdEventIds.length > 0) {
+      await prisma.webhookEvent.deleteMany({
+        where: {
+          id: { in: createdEventIds }
+        }
+      });
+    }
     createdEventIds = [];
+    createdMeasurementIds = [];
+    createdSessionIds = [];
+    createdDeviceIds = [];
   });
 
   afterAll(async () => {
+    if (createdDeviceIds.length > 0) {
+      await prisma.coverageBin.deleteMany({
+        where: {
+          deviceId: { in: createdDeviceIds }
+        }
+      });
+    }
+    if (createdSessionIds.length > 0) {
+      await prisma.coverageBin.deleteMany({
+        where: {
+          sessionId: { in: createdSessionIds }
+        }
+      });
+    }
+    if (createdMeasurementIds.length > 0) {
+      await prisma.measurement.deleteMany({
+        where: {
+          id: { in: createdMeasurementIds }
+        }
+      });
+    }
+    if (createdSessionIds.length > 0) {
+      await prisma.session.deleteMany({
+        where: {
+          id: { in: createdSessionIds }
+        }
+      });
+    }
+    if (createdDeviceIds.length > 0) {
+      await prisma.device.deleteMany({
+        where: {
+          id: { in: createdDeviceIds }
+        }
+      });
+    }
     if (createdEventIds.length > 0) {
       await prisma.webhookEvent.deleteMany({
         where: {
@@ -288,6 +363,180 @@ describe('Events API e2e', () => {
     expect(response.body.message).toContain('cursor must be formatted');
   });
 
+  it('previews and creates a recovered session from selected events', async () => {
+    const now = Date.now();
+    const deviceUid = `events-recover-device-${now}`;
+    const device = await createDevice(deviceUid);
+    const eventA = await createEvent({
+      source: WebhookEventSource.MESHTASTIC,
+      deviceUid,
+      portnum: 'POSITION_APP',
+      packetId: `events-recover-${now}-a`,
+      receivedAt: new Date(now + 1_000),
+      payloadJson: {
+        decoded: {
+          position: {
+            latitude: 49.4,
+            longitude: 7.6
+          }
+        }
+      }
+    });
+    const eventB = await createEvent({
+      source: WebhookEventSource.MESHTASTIC,
+      deviceUid,
+      portnum: 'POSITION_APP',
+      packetId: `events-recover-${now}-b`,
+      receivedAt: new Date(now + 4_000),
+      payloadJson: {
+        decoded: {
+          position: {
+            latitude: 49.401,
+            longitude: 7.602
+          }
+        }
+      }
+    });
+
+    await createMeasurementForEvent({
+      deviceId: device.id,
+      eventId: eventA.id,
+      capturedAt: new Date(now + 1_000),
+      lat: 49.4,
+      lon: 7.6
+    });
+    await createMeasurementForEvent({
+      deviceId: device.id,
+      eventId: eventB.id,
+      capturedAt: new Date(now + 4_000),
+      lat: 49.401,
+      lon: 7.602
+    });
+
+    const preview = await request(app.getHttpServer())
+      .post('/api/events/recover-session/preview')
+      .set('x-api-key', queryKeyPlaintext)
+      .send({
+        eventIds: [eventA.id, eventB.id]
+      })
+      .expect(201);
+
+    expect(preview.body).toMatchObject({
+      selectedEventCount: 2,
+      eligibleEventCount: 2,
+      eligibleMeasurementCount: 2,
+      alreadyAssignedEventCount: 0,
+      incompatibleEventCount: 0,
+      canCreate: true,
+      inferredDeviceId: device.id,
+      inferredDeviceUid: deviceUid
+    });
+    expect(preview.body.startTime).toBe(new Date(now + 1_000).toISOString());
+    expect(preview.body.endTime).toBe(new Date(now + 4_000).toISOString());
+
+    const created = await request(app.getHttpServer())
+      .post('/api/events/recover-session')
+      .set('x-api-key', queryKeyPlaintext)
+      .send({
+        eventIds: [eventA.id, eventB.id],
+        name: 'Recovered Walk',
+        notes: 'Recovered from missed start'
+      })
+      .expect(201);
+
+    expect(created.body).toMatchObject({
+      deviceId: device.id,
+      deviceUid,
+      sessionName: 'Recovered Walk',
+      selectedEventCount: 2,
+      attachedEventCount: 2,
+      attachedMeasurementCount: 2,
+      startTime: new Date(now + 1_000).toISOString(),
+      endTime: new Date(now + 4_000).toISOString(),
+      durationMs: 3_000
+    });
+    expect(typeof created.body.sessionId).toBe('string');
+    createdSessionIds.push(created.body.sessionId as string);
+
+    const createdSession = await prisma.session.findUnique({
+      where: { id: created.body.sessionId as string },
+      select: { id: true, name: true, notes: true, startedAt: true, endedAt: true }
+    });
+    expect(createdSession).not.toBeNull();
+    expect(createdSession?.name).toBe('Recovered Walk');
+    expect(createdSession?.notes).toBe('Recovered from missed start');
+    expect(createdSession?.startedAt.toISOString()).toBe(new Date(now + 1_000).toISOString());
+    expect(createdSession?.endedAt?.toISOString()).toBe(new Date(now + 4_000).toISOString());
+
+    const reassigned = await prisma.measurement.findMany({
+      where: { sourceEventId: { in: [eventA.id, eventB.id] } },
+      select: { sessionId: true }
+    });
+    expect(reassigned).toHaveLength(2);
+    expect(
+      reassigned.every((measurement) => measurement.sessionId === (created.body.sessionId as string))
+    ).toBe(true);
+  });
+
+  it('blocks recovered-session creation when selected events are already assigned', async () => {
+    const now = Date.now();
+    const device = await createDevice(`events-recover-blocked-${now}`);
+    const existingSession = await createSession(device.id, {
+      name: 'Existing',
+      startedAt: new Date(now - 60_000),
+      endedAt: new Date(now - 30_000)
+    });
+    const assignedEvent = await createEvent({
+      source: WebhookEventSource.MESHTASTIC,
+      deviceUid: device.deviceUid,
+      portnum: 'POSITION_APP',
+      packetId: `events-recover-assigned-${now}`,
+      receivedAt: new Date(now),
+      payloadJson: {
+        decoded: {
+          position: {
+            latitude: 49.5,
+            longitude: 7.7
+          }
+        }
+      }
+    });
+    await createMeasurementForEvent({
+      deviceId: device.id,
+      eventId: assignedEvent.id,
+      capturedAt: new Date(now),
+      lat: 49.5,
+      lon: 7.7,
+      sessionId: existingSession.id
+    });
+
+    const preview = await request(app.getHttpServer())
+      .post('/api/events/recover-session/preview')
+      .set('x-api-key', queryKeyPlaintext)
+      .send({
+        eventIds: [assignedEvent.id]
+      })
+      .expect(201);
+
+    expect(preview.body).toMatchObject({
+      selectedEventCount: 1,
+      alreadyAssignedEventCount: 1,
+      canCreate: false
+    });
+    expect(Array.isArray(preview.body.blockingErrors)).toBe(true);
+    expect(String(preview.body.blockingErrors[0])).toContain('already assigned');
+
+    const createAttempt = await request(app.getHttpServer())
+      .post('/api/events/recover-session')
+      .set('x-api-key', queryKeyPlaintext)
+      .send({
+        eventIds: [assignedEvent.id]
+      })
+      .expect(400);
+
+    expect(String(createAttempt.body.message)).toContain('already assigned');
+  });
+
   async function createEvent(input: {
     source: WebhookEventSource;
     deviceUid: string;
@@ -317,6 +566,65 @@ describe('Events API e2e', () => {
       }
     });
     createdEventIds.push(created.id);
+    return created;
+  }
+
+  async function createDevice(deviceUid: string) {
+    const created = await prisma.device.create({
+      data: {
+        deviceUid
+      },
+      select: {
+        id: true,
+        deviceUid: true
+      }
+    });
+    createdDeviceIds.push(created.id);
+    return created;
+  }
+
+  async function createSession(
+    deviceId: string,
+    input: {
+      name?: string;
+      startedAt: Date;
+      endedAt?: Date | null;
+    }
+  ) {
+    const created = await prisma.session.create({
+      data: {
+        deviceId,
+        name: input.name ?? null,
+        startedAt: input.startedAt,
+        endedAt: input.endedAt ?? null
+      },
+      select: { id: true }
+    });
+    createdSessionIds.push(created.id);
+    return created;
+  }
+
+  async function createMeasurementForEvent(input: {
+    deviceId: string;
+    eventId: string;
+    capturedAt: Date;
+    lat: number;
+    lon: number;
+    sessionId?: string | null;
+  }) {
+    const created = await prisma.measurement.create({
+      data: {
+        deviceId: input.deviceId,
+        sourceEventId: input.eventId,
+        sessionId: input.sessionId ?? null,
+        capturedAt: input.capturedAt,
+        lat: input.lat,
+        lon: input.lon,
+        source: 'meshtastic'
+      },
+      select: { id: true }
+    });
+    createdMeasurementIds.push(created.id);
     return created;
   }
 });


### PR DESCRIPTION
## Summary\n- add MVP recovery flow to create a session from selected contiguous Events rows\n- add backend preview/create endpoints with validation and conflict handling\n- add Events table selection (including shift-range), confirmation modal, and success navigation to new session\n- add tests for preview/create and assigned-event conflict behavior\n\n## Conflict policy\n- block creation if any selected event is already assigned to another session\n- do not reassign or duplicate event membership in MVP\n\n## Validation highlights\n- requires selected event IDs to exist\n- blocks mixed inferred measurement devices\n- blocks when no usable route/location measurements exist\n- warns on mixed raw devices and large time gaps\n\n## Verification\n- npm run -s build\n- npm --prefix frontend run -s build\n- e2e requires local DB schema alignment in this environment